### PR TITLE
AP-n/a: Changes lookmlID for Opportunities section of the app

### DIFF
--- a/application.json
+++ b/application.json
@@ -112,7 +112,7 @@
           "dashboardCollection": {
             "dashboards": [
               {
-                "lookmlID": "sales_analytics::behavior",
+                "lookmlID": "sales_analytics::opportunities",
                 "name": "Opportunities",
                 "permalink": "opportunities"
               }


### PR DESCRIPTION
NOTE: not associated with a specific JIRA issue

From "sales_analytics::behavior" To "sales_analytics::opportunities" to match the current LookML dash