### PR TITLE
Adding back in the order by id in LAST_VALUE

### DIFF
--- a/opportunity_history_by_day.view.lkml
+++ b/opportunity_history_by_day.view.lkml
@@ -57,7 +57,7 @@ view: opportunity_history_by_day {
                                   ELSE LAST_VALUE(CASE WHEN field = 'ForecastCategoryName' THEN NEW_VALUE END IGNORE NULLS)
                                           OVER (PARTITION BY opportunity_id ORDER BY created_date, field ROWS UNBOUNDED PRECEDING)
                                   END as forecast_category
-                            , LAST_VALUE(ID) OVER (PARTITION BY opportunity_id, TIMESTAMP_TRUNC(created_date,DAY) ORDER BY created_date, field ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as last_id_on_created_date
+                            , LAST_VALUE(ID) OVER (PARTITION BY opportunity_id, TIMESTAMP_TRUNC(created_date,DAY) ORDER BY created_date, field, id ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as last_id_on_created_date
                             , FIRST_VALUE(TIMESTAMP_TRUNC(created_date,DAY)) OVER (PARTITION BY opportunity_id ORDER BY created_date, field) as opportunity_created_date
                             FROM union_current_and_history
                             WHERE field IN ('Amount','CloseDate','Probability','StageName','ForecastCategoryName')


### PR DESCRIPTION
In the event that we have different values for our "oldest value" and "current value" records for a given field on a given opportunity id, we'll always want to use the "oldest value" for that field in the first snapshot. Adding a sort to ID will mean that our newest values (i.e.new_X_1) will precede our oldest values (i.e. old_X_1), and our use of LAST_VALUE will grab the oldest value rather than the newest value.