### PR TITLE
AP-303: Touch ups in core files for crossfilter dashboard

### DIFF
--- a/opportunity_history_waterfall.explore.lkml
+++ b/opportunity_history_waterfall.explore.lkml
@@ -12,4 +12,8 @@ explore: opportunity_history_waterfall_core {
     relationship: many_to_one
     sql_on: ${opportunity_history_waterfall.opportunity_id} = ${opportunity.id} ;;
   }
+  join: account {
+    sql_on: ${opportunity.account_id} = ${account.id} ;;
+    relationship: many_to_one
+  }
 }

--- a/opportunity_history_waterfall_core.view.lkml
+++ b/opportunity_history_waterfall_core.view.lkml
@@ -252,7 +252,7 @@ view: opportunity_history_waterfall_core {
             WHEN ${closed_won_last} AND ${close_date_in_range_last} THEN 'Closed Won'
             WHEN ${closed_lost_last} AND ${close_date_in_range_last} THEN 'Closed Lost'
             WHEN NOT (${close_date_in_range_last}) THEN 'Moved Out'
-            ELSE 'Unaccounted For'
+            ELSE 'Unaccounted For' -- Close Date in range but NOT Won or Lost
           END
           ;;
   }

--- a/user_core.view.lkml
+++ b/user_core.view.lkml
@@ -53,7 +53,9 @@ view: user_core {
     drill_fields: [account.name, opportunity.type, opportunity.closed_date, opportunity.total_acv]
   }
 
-  measure: count { label: "Number of Users" }
+  measure: count {
+    label: "Number of {% if _view._name == 'opportunity_owner' %} Opportunity Owners {% elsif _view._name == 'account_owner' %} Account Owners {% else %} Users {% endif %}"
+  }
 
   # field sets for drilling #
 


### PR DESCRIPTION
1. Added a join to "account" in the opportunity_history_waterfall explore
2. Added a dynamic label to the count measure in user_core.view
3. Left a comment to the forecast_category_last dimension in opportunity_history_waterfall_core.view