### PR TITLE
Changing value_format_name of win_percentage AND adding Win/Loss Ratio measure

### DIFF
--- a/opportunity_core.view.lkml
+++ b/opportunity_core.view.lkml
@@ -437,13 +437,13 @@ view: opportunity_core {
   measure: win_percentage {
     type: number
     sql: ${count_won} / NULLIF(${count_closed}, 0) ;;
-    value_format_name: percent_2
+    value_format_name: percent_1
   }
 
   measure: open_percentage {
     type: number
     sql: ${count_open} / NULLIF(${count}, 0) ;;
-    value_format_name: percent_2
+    value_format_name: percent_1
   }
 
   measure: count_new_business_won {

--- a/opportunity_core.view.lkml
+++ b/opportunity_core.view.lkml
@@ -446,6 +446,13 @@ view: opportunity_core {
     value_format_name: percent_1
   }
 
+  measure: win_to_loss_ratio {
+    type: number
+    sql: ${count_new_business_won}/IF(${count_new_business_lost} = 0, 1, ${count_new_business_lost}) ;;
+    value_format_name: decimal_2
+    drill_fields: [opp_drill_set_closed*]
+  }
+
   measure: count_new_business_won {
     label: "Number of New-Business Opportunities Won"
     type: count
@@ -453,6 +460,23 @@ view: opportunity_core {
     filters: {
       field: is_won
       value: "Yes"
+    }
+
+    filters: {
+      field: is_new_business
+      value: "yes"
+    }
+
+    drill_fields: [opp_drill_set_closed*]
+  }
+
+  measure: count_new_business_lost {
+    label: "Number of New-Business Opportunities Lost"
+    type: count
+
+    filters: {
+      field: is_won
+      value: "No"
     }
 
     filters: {


### PR DESCRIPTION
Changing the value format means we can make the "Close Rate" tile on the Sales Rep Operations Dash a bit thinner.