### PR TITLE
Updated "Sales Rep Ops" dashboard to "Sales Rep Workflow" in application.json and Dashboard LookML.

### DIFF
--- a/application.json
+++ b/application.json
@@ -89,15 +89,15 @@
           ]
         },
         {
-          "name": "Operations",
+          "name": "Workflow",
           "icon": "web-analytics/acquisitions",
           "type": "dashboardCollection",
-          "permalink": "sales_rep_operations",
+          "permalink": "sales_rep_workflow",
           "dashboardCollection": {
             "dashboards": [{
-              "lookmlID": "sales_analytics::sales_rep_operations",
+              "lookmlID": "sales_analytics::sales_rep_workflow",
               "name": "Sales Rep Operations",
-              "permalink": "sales_rep_operations"
+              "permalink": "sales_rep_workflow"
             }]
           },
           "filters": [{

--- a/sales_rep_workflow.dashboard.lookml
+++ b/sales_rep_workflow.dashboard.lookml
@@ -1,5 +1,5 @@
-- dashboard: sales_rep_operations
-  title: Sales Rep Operations
+- dashboard: sales_rep_workflow
+  title: Sales Rep Workflow
   layout: newspaper
   elements:
   - title: Sales Rep Name
@@ -27,59 +27,6 @@
     col: 0
     width: 24
     height: 2
-  - title: New Tile
-    name: New Tile
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields:
-    - opportunity.count_of_opportunities_that_need_updated_closed_date
-    limit: 500
-    query_timezone: UTC
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    single_value_title: Update Closed Date
-    show_comparison: false
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 10
-    width: 4
-    height: 4
-  - title: Opportunities with next steps
-    name: Opportunities with next steps
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields:
-    - opportunity.count_of_opportunities_with_next_steps
-    limit: 500
-    column_limit: 50
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 14
-    width: 5
-    height: 4
-  - title: Opportunities with no next steps
-    name: Opportunities with no next steps
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields:
-    - opportunity.count_of_opportunities_with_no_next_steps
-    limit: 500
-    column_limit: 50
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 19
-    width: 5
-    height: 4
   - title: Closed New Business This Year
     name: Closed New Business This Year
     model: sales_analytics
@@ -142,219 +89,10 @@
     totals_color: "#808080"
     listen:
       Sales Rep: opportunity_owner.name
-    row: 17
+    row: 25
     col: 15
     width: 9
     height: 13
-  - title: Close Rate
-    name: Close Rate
-    model: sales_analytics
-    explore: opportunity
-    type: looker_column
-    fields:
-    - opportunity.win_percentage
-    - opportunity.close_month
-    fill_fields:
-    - opportunity.close_month
-    filters:
-      opportunity.close_date: 4 quarters
-    limit: 50
-    query_timezone: America/Los_Angeles
-    trellis: ''
-    stacking: ''
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
-      options:
-        steps: 5
-    show_value_labels: true
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    point_style: none
-    series_colors: {}
-    series_types: {}
-    limit_displayed_rows: false
-    y_axes:
-    - label: ''
-      orientation: left
-      series:
-      - id: opportunity.win_percentage
-        name: Win Percentage
-        axisId: opportunity.win_percentage
-      showLabels: false
-      showValues: false
-      unpinAxis: false
-      tickDensity: default
-      type: linear
-    y_axis_combined: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: false
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    show_null_points: true
-    interpolation: linear
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 11
-    col: 0
-    width: 10
-    height: 6
-  - title: Rep Avg Deal
-    name: Rep Avg Deal
-    model: sales_analytics
-    explore: opportunity
-    type: looker_column
-    fields:
-    - opportunity.average_amount_won
-    - opportunity.close_month
-    fill_fields:
-    - opportunity.close_month
-    filters:
-      opportunity.close_date: 4 quarters
-    sorts:
-    - opportunity.close_month desc
-    limit: 50
-    query_timezone: America/Los_Angeles
-    trellis: ''
-    stacking: ''
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
-      options:
-        steps: 5
-    show_value_labels: true
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    point_style: none
-    series_colors:
-      opportunity.average_amount_won: "#EE9093"
-    series_types: {}
-    limit_displayed_rows: false
-    y_axes:
-    - label: ''
-      orientation: left
-      series:
-      - id: opportunity.average_amount_won
-        name: Average ACV  Won
-        axisId: opportunity.average_amount_won
-      showLabels: false
-      showValues: false
-      unpinAxis: false
-      tickDensity: default
-      type: linear
-    y_axis_combined: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: false
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    show_null_points: true
-    interpolation: linear
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 11
-    col: 10
-    width: 7
-    height: 6
-  - title: Segment Avg Deal
-    name: Segment Avg Deal
-    model: sales_analytics
-    explore: opportunity
-    type: looker_column
-    fields:
-    - opportunity.average_amount_won
-    - opportunity.close_month
-    fill_fields:
-    - opportunity.close_month
-    filters:
-      opportunity.close_date: 4 quarters
-    sorts:
-    - opportunity.close_month desc
-    limit: 50
-    query_timezone: America/Los_Angeles
-    trellis: ''
-    stacking: ''
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
-      options:
-        steps: 5
-    show_value_labels: true
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    point_style: none
-    series_colors:
-      opportunity.average_amount_won: "#EE9093"
-    series_types: {}
-    limit_displayed_rows: false
-    y_axes:
-    - label: ''
-      orientation: left
-      series:
-      - id: opportunity.average_amount_won
-        name: Average ACV  Won
-        axisId: opportunity.average_amount_won
-      showLabels: false
-      showValues: false
-      unpinAxis: false
-      tickDensity: default
-      type: linear
-    y_axis_combined: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: false
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    show_null_points: true
-    interpolation: linear
-    listen: {}
-    row: 11
-    col: 17
-    width: 7
-    height: 6
   - title: Opportunities By Stage
     name: Opportunities By Stage
     model: sales_analytics
@@ -427,40 +165,6 @@
     col: 0
     width: 24
     height: 5
-  - title: Upcoming Opportunities
-    name: Upcoming Opportunities
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields:
-    - opportunity.count_new_business
-    filters:
-      opportunity.is_in_stage_1: 'Yes'
-      opportunity.has_an_upcoming_first_meeting: 'Yes'
-    limit: 500
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 0
-    width: 5
-    height: 4
-  - title: Take Action on these Opportunities
-    name: Take Action on these Opportunities
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields:
-    - opportunity.count_new_business
-    filters:
-      opportunity.is_in_stage_1: 'Yes'
-      opportunity.requires_action: 'Yes'
-    limit: 500
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 5
-    width: 5
-    height: 4
   - title: Open Opportunities and Next Steps
     name: Open Opportunities and Next Steps
     model: sales_analytics
@@ -472,7 +176,7 @@
     - opportunity.type
     - opportunity.days_open
     - opportunity.created_date
-    - opportunity.custom_stage_name
+    - opportunity.stage_name
     - opportunity.next_step
     - opportunity.amount
     - opportunity.first_meeting_date
@@ -514,11 +218,374 @@
     - opportunity.first_meeting_date
     - opportunity_history_days_in_current_stage.most_recent_stage_change_date_date
     - opportunity_history_days_in_current_stage.most_recent_stage_change_date
-    listen: {}
-    row: 17
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 25
     col: 0
     width: 15
     height: 13
+  - title: Opps Requiring Action
+    name: Opps Requiring Action
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields:
+    - opportunity.count_new_business
+    filters:
+      opportunity.is_in_stage_1: 'Yes'
+      opportunity.requires_action: 'Yes'
+    limit: 500
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 5
+    width: 5
+    height: 4
+  - title: Upcoming Opps
+    name: Upcoming Opps
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields:
+    - opportunity.count_new_business
+    filters:
+      opportunity.is_in_stage_1: 'Yes'
+      opportunity.has_an_upcoming_first_meeting: 'Yes'
+    limit: 500
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 0
+    width: 5
+    height: 4
+  - title: Close Rate
+    name: Close Rate
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields:
+    - opportunity.win_percentage
+    - opportunity.close_quarter
+    fill_fields:
+    - opportunity.close_quarter
+    filters:
+      opportunity.close_date: 4 quarters
+    limit: 50
+    query_timezone: America/Los_Angeles
+    trellis: ''
+    stacking: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
+      options:
+        steps: 5
+    show_value_labels: true
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    point_style: none
+    series_colors: {}
+    series_types: {}
+    limit_displayed_rows: false
+    y_axes:
+    - label: ''
+      orientation: left
+      series:
+      - id: opportunity.win_percentage
+        name: Win Percentage
+        axisId: opportunity.win_percentage
+      showLabels: false
+      showValues: false
+      unpinAxis: false
+      tickDensity: default
+      type: linear
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    show_null_points: true
+    interpolation: linear
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 11
+    col: 0
+    width: 12
+    height: 7
+  - title: Win / Loss Ratio
+    name: Win / Loss Ratio
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields:
+    - opportunity.win_to_loss_ratio
+    - opportunity.close_quarter
+    fill_fields:
+    - opportunity.close_quarter
+    filters:
+      opportunity.close_date: 4 quarters
+    limit: 50
+    column_limit: 50
+    query_timezone: America/Los_Angeles
+    trellis: ''
+    stacking: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
+      options:
+        steps: 5
+    show_value_labels: true
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: false
+    show_view_names: false
+    point_style: none
+    series_colors:
+      opportunity.win_to_loss_ratio: "#170658"
+    series_types: {}
+    limit_displayed_rows: false
+    y_axes:
+    - label: ''
+      orientation: left
+      series:
+      - id: opportunity.win_to_loss_ratio
+        name: Win to Loss Ratio
+        axisId: opportunity.win_to_loss_ratio
+      showLabels: false
+      showValues: false
+      unpinAxis: false
+      tickDensity: default
+      type: linear
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_null_points: true
+    interpolation: linear
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 18
+    col: 0
+    width: 12
+    height: 7
+  - title: Rep Avg Deal
+    name: Rep Avg Deal
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields:
+    - opportunity.average_amount_won
+    - opportunity.close_quarter
+    fill_fields:
+    - opportunity.close_quarter
+    filters:
+      opportunity.close_date: 4 quarters
+    limit: 50
+    query_timezone: America/Los_Angeles
+    trellis: ''
+    stacking: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
+      options:
+        steps: 5
+    show_value_labels: true
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    point_style: none
+    series_colors:
+      opportunity.average_amount_won: "#FFB690"
+    series_types: {}
+    limit_displayed_rows: false
+    y_axes:
+    - label: ''
+      orientation: left
+      series:
+      - id: opportunity.average_amount_won
+        name: Average ACV  Won
+        axisId: opportunity.average_amount_won
+      showLabels: false
+      showValues: false
+      unpinAxis: false
+      tickDensity: default
+      type: linear
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_null_points: true
+    interpolation: linear
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 11
+    col: 12
+    width: 12
+    height: 7
+  - title: Segment Avg Deal
+    name: Segment Avg Deal
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields:
+    - opportunity.average_amount_won
+    - opportunity.close_quarter
+    fill_fields:
+    - opportunity.close_quarter
+    filters:
+      opportunity.close_date: 4 quarters
+    limit: 50
+    query_timezone: America/Los_Angeles
+    trellis: ''
+    stacking: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
+      options:
+        steps: 5
+    show_value_labels: true
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    point_style: none
+    series_colors:
+      opportunity.average_amount_won: "#EE9093"
+    series_types: {}
+    limit_displayed_rows: false
+    y_axes:
+    - label: ''
+      orientation: left
+      series:
+      - id: opportunity.average_amount_won
+        name: Average ACV  Won
+        axisId: opportunity.average_amount_won
+      showLabels: false
+      showValues: false
+      unpinAxis: false
+      tickDensity: default
+      type: linear
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_null_points: true
+    interpolation: linear
+    listen: {}
+    row: 18
+    col: 12
+    width: 12
+    height: 7
+  - title: New Tile
+    name: New Tile
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields:
+    - opportunity.number_of_opportunities_that_need_updated_closed_date
+    limit: 500
+    query_timezone: UTC
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    single_value_title: Update Closed Date
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 10
+    width: 4
+    height: 4
+  - title: Opps with Next Steps
+    name: Opps with Next Steps
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields:
+    - opportunity.number_of_opportunities_with_next_steps
+    limit: 500
+    column_limit: 50
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 14
+    width: 5
+    height: 4
+  - title: Opps with No Next Steps
+    name: Opps with No Next Steps
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields:
+    - opportunity.number_of_opportunities_with_no_next_steps
+    limit: 500
+    column_limit: 50
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 19
+    width: 5
+    height: 4
   filters:
   - name: Sales Rep
     title: Sales Rep


### PR DESCRIPTION
Changes to the dash include:
1. Some of the measures that the single value viz's were reliant on went through a name change, so needed to get the appropriate measures back in
2. Name of the dash swapped from "Sales Rep Ops" to "Sales Rep Workflow"