### PR TITLE
Updating sales_leadership_overview dash and removing "state" filter from sales_leadership_overview dash

### DIFF
--- a/application.json
+++ b/application.json
@@ -50,16 +50,8 @@
       }],
       "defaultDashboard": "sales_leadership_overview"
     },
-    "filters": [{
-      "autoSuggest": {
-        "model": "sales_analytics",
-        "view": "account"
-      },
-      "field": "account.billing_state",
-      "name": "State",
-      "type": "Select",
-      "dashboardAlias": "State"
-    }]
+    "filters": [
+    ]
   },
   "sections": [{
       "description": "Sales Rep Section: Includes the Rep Performance Dashbaord, Rep Operations Dashboard, AE Management Report, and Rep Ramping Report",

--- a/sales_leadership_overview.dashboard.lookml
+++ b/sales_leadership_overview.dashboard.lookml
@@ -2,182 +2,6 @@
   title: Sales Leadership Quarter Overview
   layout: newspaper
   elements:
-  - title: New Customers
-    name: New Customers
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields:
-    - opportunity.count_new_business_won
-    - opportunity.close_year
-    pivots:
-    - opportunity.close_year
-    fill_fields:
-    - opportunity.close_year
-    filters:
-      opportunity.close_date: 0 quarters ago for 1 quarter, 4 quarters ago for 1 quarter
-      opportunity.type: New Business
-    sorts:
-    - opportunity.close_year desc
-    limit: 500
-    column_limit: 50
-    dynamic_fields:
-    - table_calculation: this_quarter
-      label: This Quarter
-      expression: 'pivot_index(${opportunity.count_new_business_won}, 1)
-
-        '
-      value_format:
-      value_format_name:
-      _kind_hint: supermeasure
-      _type_hint: number
-    - table_calculation: change
-      label: Change
-      expression: "(pivot_index(${opportunity.count_new_business_won}, 1) - pivot_index(${opportunity.count_new_business_won},\
-        \ 2))/pivot_index(${opportunity.count_new_business_won}, 2)"
-      value_format:
-      value_format_name: percent_0
-      _kind_hint: supermeasure
-      _type_hint: number
-    filter_expression: "((extract_years(now())=extract_years(${opportunity.close_year})\n\
-      \   AND ${opportunity.close_year} <= now())\n\nOR \n\n(((extract_years(now())-1)=extract_years(${opportunity.close_year})\n\
-      \  AND ${opportunity.close_year} <= add_years(-1,now()))\n\nAND\n\n(extract_months(${opportunity.close_date})\
-      \ = extract_months(now())\nAND\nextract_days(${opportunity.close_date}) <= extract_days(now()))\n\
-      \nOR\n\nextract_months(${opportunity.close_date}) < extract_months(now())))"
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: change
-    comparison_reverse_colors: false
-    show_comparison_label: false
-    font_size: small
-    hidden_fields:
-    - opportunity.count_new_business_won
-    listen:
-      Manager: opportunity_owner.manager
-      Business Segment: account.business_segment
-    row: 2
-    col: 18
-    width: 3
-    height: 4
-  - title: Pipeline Forecast
-    name: Pipeline Forecast
-    model: sales_analytics
-    explore: opportunity
-    type: looker_column
-    fields:
-    - opportunity.close_quarter
-    - opportunity.total_pipeline_amount
-    - opportunity.custom_stage_name
-    pivots:
-    - opportunity.custom_stage_name
-    fill_fields:
-    - opportunity.close_quarter
-    filters:
-      opportunity.close_quarter: 0 quarters ago for 4 quarters
-      opportunity.custom_stage_name: "-Unknown"
-    sorts:
-    - opportunity.close_quarter
-    - opportunity.custom_stage_name
-    limit: 500
-    query_timezone: America/Los_Angeles
-    trellis: ''
-    stacking: normal
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      custom:
-        id: 1246f89a-2e59-24c6-cbc6-cdef2825eb9b
-        label: Custom
-        type: continuous
-        stops:
-        - color: "#FED8A0"
-          offset: 0
-        - color: "#C762AD"
-          offset: 50
-        - color: "#462C9D"
-          offset: 100
-      options:
-        steps: 5
-    show_value_labels: false
-    label_density: 25
-    label_color:
-    - "#FFFFFF"
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: false
-    show_view_names: false
-    point_style: none
-    series_colors: {}
-    series_types: {}
-    limit_displayed_rows: false
-    hidden_series:
-    - Lost - 6 - opportunity.total_revenue
-    - Under 20% - 5 - opportunity.total_revenue
-    - Won - 0 - opportunity.total_pipeline_amount
-    - Lost - 6 - opportunity.total_pipeline_amount
-    - Closed Won - 6 - opportunity.total_pipeline_amount
-    y_axes:
-    - label: Amount in Pipeline
-      orientation: left
-      series:
-      - id: Won - 0 - opportunity.total_pipeline_amount
-        name: Won
-        axisId: Won - 0 - opportunity.total_pipeline_amount
-      - id: Above 80% - 1 - opportunity.total_pipeline_amount
-        name: Above 80%
-        axisId: Above 80% - 1 - opportunity.total_pipeline_amount
-      - id: 60 - 80% - 2 - opportunity.total_pipeline_amount
-        name: 60 - 80%
-        axisId: 60 - 80% - 2 - opportunity.total_pipeline_amount
-      - id: 40 - 60% - 3 - opportunity.total_pipeline_amount
-        name: 40 - 60%
-        axisId: 40 - 60% - 3 - opportunity.total_pipeline_amount
-      - id: 20 - 40% - 4 - opportunity.total_pipeline_amount
-        name: 20 - 40%
-        axisId: 20 - 40% - 4 - opportunity.total_pipeline_amount
-      - id: Under 20% - 5 - opportunity.total_pipeline_amount
-        name: Under 20%
-        axisId: Under 20% - 5 - opportunity.total_pipeline_amount
-      - id: Lost - 6 - opportunity.total_pipeline_amount
-        name: Lost
-        axisId: Lost - 6 - opportunity.total_pipeline_amount
-      showLabels: false
-      showValues: false
-      valueFormat: $0.0,, "M"
-      unpinAxis: false
-      tickDensity: default
-      tickDensityCustom: 5
-      type: linear
-    y_axis_combined: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    x_axis_label: ''
-    show_x_axis_ticks: true
-    x_axis_datetime_label: ''
-    x_axis_scale: ordinal
-    y_axis_scale_mode: linear
-    label_value_format: ''
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: true
-    show_silhouette: false
-    totals_color: "#707070"
-    show_null_points: true
-    interpolation: linear
-    listen:
-      Manager: opportunity_owner.manager
-      Business Segment: account.business_segment
-    row: 11
-    col: 12
-    width: 12
-    height: 10
   - title: Quarterly New Bookings by Business Segment
     name: Quarterly New Bookings by Business Segment
     model: sales_analytics
@@ -569,149 +393,76 @@
     col: 0
     width: 10
     height: 6
-  - title: Quota Attainment
-    name: Quota Attainment
+  - title: of Quota
+    name: of Quota
     model: sales_analytics
     explore: opportunity
-    type: looker_area
+    type: single_value
     fields:
-    - opportunity.day_of_quarter
-    - opportunity.total_closed_won_new_business_amount
     - opportunity.close_quarter
-    pivots:
+    - opportunity.total_closed_won_new_business_amount
+    - quota_numbers.quarterly_aggregate_quota_measure
+    fill_fields:
     - opportunity.close_quarter
     filters:
-      opportunity.close_quarter: this quarter, last quarter, 4 quarters ago for 1
-        quarter
+      opportunity.close_year: this quarter,next quarter
       opportunity_owner.manager: ''
       account.business_segment: ''
     sorts:
-    - opportunity.close_quarter desc
-    - opportunity.day_of_quarter
-    limit: 500
+    - opportunity.close_quarter
+    limit: 1000
     column_limit: 50
     dynamic_fields:
-    - table_calculation: quota
-      label: Quota
-      expression: 10000000 + if(is_null(${opportunity.total_closed_won_new_business_amount}),0,0)*0
+    - table_calculation: of_quota_hit
+      label: "% of Quota Hit"
+      expression: "${opportunity.total_closed_won_new_business_amount} / ${quota_numbers.quarterly_aggregate_quota_measure}"
       value_format:
-      value_format_name: usd_0
+      value_format_name: percent_0
       _kind_hint: measure
       _type_hint: number
-    - table_calculation: running_total_of_amount
-      label: Running Total of Amount
-      expression: if(diff_days(trunc_days(now()),add_days(${opportunity.day_of_quarter}
-        - 1,${opportunity.close_quarter})) > 0, null,running_total(${opportunity.total_closed_won_new_business_amount}))
-      value_format:
-      value_format_name: usd_0
-      _kind_hint: measure
-      _type_hint: number
-    - table_calculation: percent_of_quota
-      label: Percent of Quota
-      expression: "${running_total_of_amount}/${quota}"
-      value_format:
-      value_format_name: percent_2
-      _kind_hint: measure
-      _type_hint: number
-    - table_calculation: goal
-      label: Goal
-      expression: if(mod(row(),2) = 0,pivot_where(pivot_column() = 1, 1)*0 + 1,null)
+    - table_calculation: current_day_of_the_quarter
+      label: Current Day of the Quarter
+      expression: diff_days(${opportunity.close_quarter},trunc_days(now())) + 1
       value_format:
       value_format_name:
-      _kind_hint: supermeasure
+      _kind_hint: dimension
       _type_hint: number
-    trellis: ''
-    stacking: ''
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
-      options:
-        steps: 5
-    show_value_labels: false
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: false
-    show_view_names: false
-    point_style: none
-    series_colors: {}
-    series_labels:
-      2019-01 - of_quota: This Quarter
-      2018-10 - of_quota: Last Quarter
-      2019-01 - percent_of_quota: This Quarter
-      2018-10 - percent_of_quota: Last Quarter
-      2018-01 - percent_of_quota: This Quarter - Last Year
-    series_types:
-      goal: scatter
-    series_point_styles: {}
-    limit_displayed_rows: false
-    hidden_series:
-    - 2018-10 - calculation_5
-    - 2018-07 - percent_of_quota
-    - 2018-07 - calculation_5
-    - 2018-04 - calculation_5
-    - 2018-01 - calculation_5
-    - 2018-04 - percent_of_quota
-    y_axes:
-    - label: ''
-      orientation: left
-      series:
-      - id: 2019-01 - of_quota
-        name: This Quarter
-        axisId: of_quota
-      - id: 2018-10 - of_quota
-        name: Last Quarter
-        axisId: of_quota
-      - id: 2018-07 - of_quota
-        name: 2018-Q3 - % of Quota
-        axisId: of_quota
-      - id: 2018-04 - of_quota
-        name: 2018-Q2 - % of Quota
-        axisId: of_quota
-      - id: 2018-01 - of_quota
-        name: 2018-Q1 - % of Quota
-        axisId: of_quota
-      - id: goal
-        name: Goal
-        axisId: goal
-      showLabels: true
-      showValues: true
-      maxValue:
-      minValue:
-      valueFormat: 0%
-      unpinAxis: false
-      tickDensity: default
-      tickDensityCustom: 5
-      type: linear
-    y_axis_combined: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    show_null_points: false
-    interpolation: linear
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
+    - table_calculation: number_of_days_in_the_quarter
+      label: Number of Days in the Quarter
+      expression: diff_days(${opportunity.close_quarter},offset(${opportunity.close_quarter},1))
+      value_format:
+      value_format_name:
+      _kind_hint: dimension
+      _type_hint: number
+    - table_calculation: percent_of_the_way_through_the_quarter
+      label: Percent of the way through the quarter
+      expression: "${current_day_of_the_quarter}/${number_of_days_in_the_quarter}"
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: dimension
+      _type_hint: number
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    show_comparison: true
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    comparison_label: Quarter Complete
+    font_size: medium
+    text_color: black
     hidden_fields:
-    - quota_quarter_goals.quota_sum
-    - quota
     - opportunity.total_closed_won_revenue
     - opportunity.total_closed_won_new_business_amount
-    - running_total_of_amount
-    - current_date
+    - opportunity.close_quarter
+    - current_day_of_the_quarter
+    - number_of_days_in_the_quarter
+    - quota_numbers.quarterly_aggregate_quota_measure
     listen: {}
-    row: 0
-    col: 0
-    width: 15
-    height: 11
+    row: 2
+    col: 21
+    width: 3
+    height: 4
   - title: Open Opportunity Funnel
     name: Open Opportunity Funnel
     model: sales_analytics
@@ -901,138 +652,234 @@
     col: 10
     width: 14
     height: 14
-  - title: New Revenue
-    name: New Revenue
+  - title: Bookings by Geography
+    name: Bookings by Geography
     model: sales_analytics
     explore: opportunity
-    type: single_value
+    type: looker_map
     fields:
-    - opportunity.close_year
+    - account.billing_state
     - opportunity.total_closed_won_new_business_amount
-    pivots:
-    - opportunity.close_year
-    fill_fields:
-    - opportunity.close_year
     filters:
-      opportunity.close_date: 0 quarters ago for 1 quarter, 4 quarters ago for 1 quarter
-      opportunity.type: New Business
+      account.business_segment: ''
+      account.billing_country: USA,United States
+      opportunity.total_closed_won_new_business_amount: ">0"
+      opportunity_owner.manager: ''
     sorts:
-    - opportunity.close_year desc
-    dynamic_fields:
-    - table_calculation: this_year
-      label: This Year
-      expression: pivot_index(${opportunity.total_closed_won_new_business_amount},
-        1) - pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)
-      value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00'
-      value_format_name:
-      _kind_hint: supermeasure
-      _type_hint: number
-    - table_calculation: change
-      label: Change
-      expression: |2-
-
-        (pivot_index(${opportunity.total_closed_won_new_business_amount}, 1) - pivot_index(${opportunity.total_closed_won_new_business_amount}, 2))/pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)
-      value_format:
-      value_format_name: percent_0
-      _kind_hint: supermeasure
-      _type_hint: number
-    filter_expression: "((extract_years(now())=extract_years(${opportunity.close_year})\n\
-      \   AND ${opportunity.close_year} <= now())\n\nOR \n\n(((extract_years(now())-1)=extract_years(${opportunity.close_year})\n\
-      \  AND ${opportunity.close_year} <= add_years(-1,now()))\n\nAND\n\n(extract_months(${opportunity.close_date})\
-      \ = extract_months(now())\nAND\nextract_days(${opportunity.close_date}) <= extract_days(now()))\n\
-      \nOR\n\nextract_months(${opportunity.close_date}) < extract_months(now())))"
+    - account.billing_state
+    limit: 500
+    column_limit: 50
+    filter_expression: length(${account.billing_state}) = 2
+    map_plot_mode: points
+    heatmap_gridlines: false
+    heatmap_gridlines_empty: false
+    heatmap_opacity: 0.5
+    show_region_field: true
+    draw_map_labels_above_data: true
+    map_tile_provider: light
+    map_position: custom
+    map_latitude: 38.89103282648846
+    map_longitude: -96.9291114807129
+    map_zoom: 4
+    map_scale_indicator: 'off'
+    map_pannable: false
+    map_zoomable: false
+    map_marker_type: circle
+    map_marker_icon_name: default
+    map_marker_radius_mode: proportional_value
+    map_marker_units: meters
+    map_marker_proportional_scale_type: linear
+    map_marker_color_mode: fixed
+    show_view_names: false
+    show_legend: true
+    map_value_colors:
+    - "#170658"
+    - "#a49bc1"
+    quantize_map_value_colors: false
+    reverse_map_value_colors: true
+    map: usa
+    map_projection: ''
+    quantize_colors: true
+    stacking: ''
     color_application:
       collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7
       palette_id: fb7bb53e-b77b-4ab6-8274-9d420d3d73f3
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: change
-    comparison_reverse_colors: false
-    show_comparison_label: false
-    font_size: medium
-    text_color: black
+      options:
+        steps: 5
+    show_value_labels: true
+    label_density: 25
+    font_size: '12'
+    legend_position: center
+    hide_legend: true
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    point_style: none
+    series_colors: {}
+    limit_displayed_rows: false
+    y_axis_combined: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    y_axis_orientation:
+    - left
+    - right
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    series_types: {}
     hidden_fields:
-    - opportunity.total_closed_won_revenue
-    - change
-    listen:
-      Manager: opportunity_owner.manager
-      Business Segment: account.business_segment
-    row: 0
-    col: 15
-    width: 9
-    height: 2
-  - title: of Quota
-    name: of Quota
+    listen: {}
+    row: 21
+    col: 10
+    width: 14
+    height: 12
+  - title: Quota Attainment
+    name: Quota Attainment
     model: sales_analytics
     explore: opportunity
-    type: single_value
+    type: looker_area
     fields:
-    - opportunity.close_quarter
+    - opportunity.day_of_quarter
     - opportunity.total_closed_won_new_business_amount
     - quota_numbers.quarterly_aggregate_quota_measure
-    fill_fields:
+    - opportunity.close_quarter
+    pivots:
     - opportunity.close_quarter
     filters:
-      opportunity.close_year: this quarter,next quarter
+      opportunity.close_quarter: this quarter, last quarter, 4 quarters ago for 1
+        quarter
       opportunity_owner.manager: ''
       account.business_segment: ''
     sorts:
-    - opportunity.close_quarter
-    limit: 1000
+    - opportunity.close_quarter desc
+    - opportunity.day_of_quarter
+    limit: 500
     column_limit: 50
     dynamic_fields:
-    - table_calculation: of_quota_hit
-      label: "% of Quota Hit"
-      expression: "${opportunity.total_closed_won_new_business_amount} / ${quota_numbers.quarterly_aggregate_quota_measure}"
+    - table_calculation: running_total_of_amount
+      label: Running Total of Amount
+      expression: if(diff_days(trunc_days(now()),add_days(${opportunity.day_of_quarter}
+        - 1,${opportunity.close_quarter})) > 0, null,running_total(${opportunity.total_closed_won_new_business_amount}))
       value_format:
-      value_format_name: percent_0
+      value_format_name: usd_0
       _kind_hint: measure
       _type_hint: number
-    - table_calculation: current_day_of_the_quarter
-      label: Current Day of the Quarter
-      expression: diff_days(${opportunity.close_quarter},trunc_days(now())) + 1
+    - table_calculation: percent_of_quota
+      label: Percent of Quota
+      expression: "${running_total_of_amount}/${quota_numbers.quarterly_aggregate_quota_measure}"
+      value_format:
+      value_format_name: percent_2
+      _kind_hint: measure
+      _type_hint: number
+    - table_calculation: goal
+      label: Goal
+      expression: if(mod(row(),2) = 0,pivot_where(pivot_column() = 1, 1)*0 + 1,null)
       value_format:
       value_format_name:
-      _kind_hint: dimension
+      _kind_hint: supermeasure
       _type_hint: number
-    - table_calculation: number_of_days_in_the_quarter
-      label: Number of Days in the Quarter
-      expression: diff_days(${opportunity.close_quarter},offset(${opportunity.close_quarter},1))
-      value_format:
-      value_format_name:
-      _kind_hint: dimension
-      _type_hint: number
-    - table_calculation: percent_of_the_way_through_the_quarter
-      label: Percent of the way through the quarter
-      expression: "${current_day_of_the_quarter}/${number_of_days_in_the_quarter}"
-      value_format:
-      value_format_name: percent_0
-      _kind_hint: dimension
-      _type_hint: number
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    comparison_label: Quarter Complete
-    font_size: medium
-    text_color: black
+    trellis: ''
+    stacking: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
+      options:
+        steps: 5
+    show_value_labels: false
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: false
+    show_view_names: false
+    point_style: none
+    series_colors: {}
+    series_labels:
+      2019-01 - of_quota: This Quarter
+      2018-10 - of_quota: Last Quarter
+      2019-01 - percent_of_quota: This Quarter
+      2018-10 - percent_of_quota: Last Quarter
+      2018-01 - percent_of_quota: This Quarter - Last Year
+    series_types:
+      goal: scatter
+    series_point_styles: {}
+    limit_displayed_rows: false
+    hidden_series:
+    - 2018-10 - calculation_5
+    - 2018-07 - percent_of_quota
+    - 2018-07 - calculation_5
+    - 2018-04 - calculation_5
+    - 2018-01 - calculation_5
+    - 2018-04 - percent_of_quota
+    y_axes:
+    - label: ''
+      orientation: left
+      series:
+      - id: 2019-01 - of_quota
+        name: This Quarter
+        axisId: of_quota
+      - id: 2018-10 - of_quota
+        name: Last Quarter
+        axisId: of_quota
+      - id: 2018-07 - of_quota
+        name: 2018-Q3 - % of Quota
+        axisId: of_quota
+      - id: 2018-04 - of_quota
+        name: 2018-Q2 - % of Quota
+        axisId: of_quota
+      - id: 2018-01 - of_quota
+        name: 2018-Q1 - % of Quota
+        axisId: of_quota
+      - id: goal
+        name: Goal
+        axisId: goal
+      showLabels: true
+      showValues: true
+      maxValue:
+      minValue:
+      valueFormat: 0%
+      unpinAxis: false
+      tickDensity: default
+      tickDensityCustom: 5
+      type: linear
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    show_null_points: false
+    interpolation: linear
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
     hidden_fields:
+    - quota_quarter_goals.quota_sum
     - opportunity.total_closed_won_revenue
     - opportunity.total_closed_won_new_business_amount
-    - opportunity.close_quarter
-    - current_day_of_the_quarter
-    - number_of_days_in_the_quarter
+    - running_total_of_amount
+    - current_date
     - quota_numbers.quarterly_aggregate_quota_measure
     listen: {}
-    row: 2
-    col: 21
-    width: 3
-    height: 4
+    row: 0
+    col: 0
+    width: 15
+    height: 11
   - title: Performance vs Quota
     name: Performance vs Quota
     model: sales_analytics
@@ -1040,8 +887,8 @@
     type: looker_line
     fields:
     - opportunity.close_date
-    - opportunity.total_closed_won_amount
     - quota_numbers.quarterly_aggregate_quota_measure
+    - opportunity.total_closed_won_new_business_amount
     fill_fields:
     - opportunity.close_date
     filters:
@@ -1062,14 +909,14 @@
       _type_hint: number
     - table_calculation: cumulative_quota
       label: Cumulative Quota
-      expression: running_total(${quota_per_day}) + ${opportunity.total_closed_won_amount}*0
+      expression: running_total(${quota_per_day}) + ${opportunity.total_closed_won_new_business_amount}*0
       value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00'
       value_format_name:
       _kind_hint: measure
       _type_hint: number
     - table_calculation: cumulative_total_won
       label: Cumulative Total Won
-      expression: running_total(${opportunity.total_closed_won_amount})
+      expression: running_total(${opportunity.total_closed_won_new_business_amount})
       value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00'
       value_format_name:
       _kind_hint: measure
@@ -1165,126 +1012,247 @@
     text_color: black
     hidden_fields:
     - opportunity.total_closed_won_revenue
-    - opportunity.total_closed_won_amount
     - quota_per_day
     - quota_numbers.quarterly_aggregate_quota_measure
     - quota_as_table_calc
     - grab_quota_value
+    - opportunity.total_closed_won_new_business_amount
     hidden_points_if_no:
     - is_before_today
+    listen: {}
     row: 6
     col: 15
     width: 9
     height: 5
-  - title: Bookings by Geography
-    name: Bookings by Geography
+  - title: New Customers
+    name: New Customers
     model: sales_analytics
     explore: opportunity
-    type: looker_map
+    type: single_value
     fields:
-    - account.billing_state
-    - opportunity.total_closed_won_new_business_amount
+    - opportunity.count_new_business_won
+    - opportunity.close_year
+    pivots:
+    - opportunity.close_year
+    fill_fields:
+    - opportunity.close_year
     filters:
-      account.business_segment: ''
-      account.billing_country: USA,United States
-      opportunity.total_closed_won_new_business_amount: ">0"
-      opportunity_owner.manager: ''
+      opportunity.close_date: 0 quarters ago for 1 quarter, 4 quarters ago for 1 quarter
+      opportunity.type: New Business
     sorts:
-    - account.billing_state
+    - opportunity.close_year desc
     limit: 500
     column_limit: 50
-    filter_expression: length(${account.billing_state}) = 2
-    map_plot_mode: points
-    heatmap_gridlines: false
-    heatmap_gridlines_empty: false
-    heatmap_opacity: 0.5
-    show_region_field: true
-    draw_map_labels_above_data: true
-    map_tile_provider: light
-    map_position: custom
-    map_latitude: 38.89103282648846
-    map_longitude: -96.9291114807129
-    map_zoom: 4
-    map_scale_indicator: 'off'
-    map_pannable: false
-    map_zoomable: false
-    map_marker_type: circle
-    map_marker_icon_name: default
-    map_marker_radius_mode: proportional_value
-    map_marker_units: meters
-    map_marker_proportional_scale_type: linear
-    map_marker_color_mode: fixed
-    show_view_names: false
-    show_legend: true
-    map_value_colors:
-    - "#170658"
-    - "#a49bc1"
-    quantize_map_value_colors: false
-    reverse_map_value_colors: true
-    map: usa
-    map_projection: ''
-    quantize_colors: true
-    stacking: ''
+    dynamic_fields:
+    - table_calculation: this_quarter
+      label: This Quarter
+      expression: 'pivot_index(${opportunity.count_new_business_won}, 1)
+
+        '
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      _type_hint: number
+    - table_calculation: change
+      label: Change
+      expression: "(pivot_index(${opportunity.count_new_business_won}, 1) - pivot_index(${opportunity.count_new_business_won},\
+        \ 2))/pivot_index(${opportunity.count_new_business_won}, 2)"
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: supermeasure
+      _type_hint: number
+    filter_expression: "((extract_years(now())=extract_years(${opportunity.close_year})\n\
+      \   AND ${opportunity.close_year} <= now())\n\nOR \n\n(((extract_years(now())-1)=extract_years(${opportunity.close_year})\n\
+      \  AND ${opportunity.close_year} <= add_years(-1,now()))\n\nAND\n\n(extract_months(${opportunity.close_date})\
+      \ = extract_months(now())\nAND\nextract_days(${opportunity.close_date}) <= extract_days(now()))\n\
+      \nOR\n\nextract_months(${opportunity.close_date}) < extract_months(now())))"
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: false
+    font_size: small
+    hidden_fields:
+    - opportunity.count_new_business_won
+    listen: {}
+    row: 2
+    col: 18
+    width: 3
+    height: 4
+  - title: New Revenue
+    name: New Revenue
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields:
+    - opportunity.close_year
+    - opportunity.total_closed_won_new_business_amount
+    pivots:
+    - opportunity.close_year
+    fill_fields:
+    - opportunity.close_year
+    filters:
+      opportunity.close_date: 0 quarters ago for 1 quarter, 4 quarters ago for 1 quarter
+      opportunity.type: New Business
+    sorts:
+    - opportunity.close_year desc
+    dynamic_fields:
+    - table_calculation: this_year
+      label: This Year
+      expression: pivot_index(${opportunity.total_closed_won_new_business_amount},
+        1) - pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)
+      value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00'
+      value_format_name:
+      _kind_hint: supermeasure
+      _type_hint: number
+    - table_calculation: change
+      label: Change
+      expression: |2-
+
+        (pivot_index(${opportunity.total_closed_won_new_business_amount}, 1) - pivot_index(${opportunity.total_closed_won_new_business_amount}, 2))/pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: supermeasure
+      _type_hint: number
+    filter_expression: "((extract_years(now())=extract_years(${opportunity.close_year})\n\
+      \   AND ${opportunity.close_year} <= now())\n\nOR \n\n(((extract_years(now())-1)=extract_years(${opportunity.close_year})\n\
+      \  AND ${opportunity.close_year} <= add_years(-1,now()))\n\nAND\n\n(extract_months(${opportunity.close_date})\
+      \ = extract_months(now())\nAND\nextract_days(${opportunity.close_date}) <= extract_days(now()))\n\
+      \nOR\n\nextract_months(${opportunity.close_date}) < extract_months(now())))"
     color_application:
       collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7
       palette_id: fb7bb53e-b77b-4ab6-8274-9d420d3d73f3
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: false
+    font_size: medium
+    text_color: black
+    hidden_fields:
+    - opportunity.total_closed_won_revenue
+    - change
+    listen: {}
+    row: 0
+    col: 15
+    width: 9
+    height: 2
+  - title: Pipeline Forecast
+    name: Pipeline Forecast
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields:
+    - opportunity.close_quarter
+    - opportunity.total_pipeline_amount
+    - opportunity.custom_stage_name
+    pivots:
+    - opportunity.custom_stage_name
+    fill_fields:
+    - opportunity.close_quarter
+    filters:
+      opportunity.close_quarter: 0 quarters ago for 4 quarters
+      opportunity.custom_stage_name: "-Unknown"
+    sorts:
+    - opportunity.close_quarter
+    - opportunity.custom_stage_name
+    limit: 500
+    query_timezone: America/Los_Angeles
+    trellis: ''
+    stacking: normal
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      custom:
+        id: 1246f89a-2e59-24c6-cbc6-cdef2825eb9b
+        label: Custom
+        type: continuous
+        stops:
+        - color: "#FED8A0"
+          offset: 0
+        - color: "#C762AD"
+          offset: 50
+        - color: "#462C9D"
+          offset: 100
       options:
         steps: 5
-    show_value_labels: true
+    show_value_labels: false
     label_density: 25
-    font_size: '12'
+    label_color:
+    - "#FFFFFF"
     legend_position: center
-    hide_legend: true
     x_axis_gridlines: false
-    y_axis_gridlines: true
+    y_axis_gridlines: false
+    show_view_names: false
     point_style: none
     series_colors: {}
+    series_types: {}
     limit_displayed_rows: false
-    y_axis_combined: false
+    hidden_series:
+    - Lost - 6 - opportunity.total_revenue
+    - Under 20% - 5 - opportunity.total_revenue
+    - Won - 0 - opportunity.total_pipeline_amount
+    - Lost - 6 - opportunity.total_pipeline_amount
+    - Closed Won - 6 - opportunity.total_pipeline_amount
+    y_axes:
+    - label: Amount in Pipeline
+      orientation: left
+      series:
+      - id: Won - 0 - opportunity.total_pipeline_amount
+        name: Won
+        axisId: Won - 0 - opportunity.total_pipeline_amount
+      - id: Above 80% - 1 - opportunity.total_pipeline_amount
+        name: Above 80%
+        axisId: Above 80% - 1 - opportunity.total_pipeline_amount
+      - id: 60 - 80% - 2 - opportunity.total_pipeline_amount
+        name: 60 - 80%
+        axisId: 60 - 80% - 2 - opportunity.total_pipeline_amount
+      - id: 40 - 60% - 3 - opportunity.total_pipeline_amount
+        name: 40 - 60%
+        axisId: 40 - 60% - 3 - opportunity.total_pipeline_amount
+      - id: 20 - 40% - 4 - opportunity.total_pipeline_amount
+        name: 20 - 40%
+        axisId: 20 - 40% - 4 - opportunity.total_pipeline_amount
+      - id: Under 20% - 5 - opportunity.total_pipeline_amount
+        name: Under 20%
+        axisId: Under 20% - 5 - opportunity.total_pipeline_amount
+      - id: Lost - 6 - opportunity.total_pipeline_amount
+        name: Lost
+        axisId: Lost - 6 - opportunity.total_pipeline_amount
+      showLabels: false
+      showValues: false
+      valueFormat: $0.0,, "M"
+      unpinAxis: false
+      tickDensity: default
+      tickDensityCustom: 5
+      type: linear
+    y_axis_combined: true
     show_y_axis_labels: true
     show_y_axis_ticks: true
     y_axis_tick_density: default
     y_axis_tick_density_custom: 5
     show_x_axis_label: true
+    x_axis_label: ''
     show_x_axis_ticks: true
-    x_axis_scale: auto
+    x_axis_datetime_label: ''
+    x_axis_scale: ordinal
     y_axis_scale_mode: linear
+    label_value_format: ''
     x_axis_reversed: false
     y_axis_reversed: false
     plot_size_by_field: false
-    y_axis_orientation:
-    - left
-    - right
     ordering: none
     show_null_labels: false
-    show_totals_labels: false
+    show_totals_labels: true
     show_silhouette: false
-    totals_color: "#808080"
-    series_types: {}
-    hidden_fields:
+    totals_color: "#707070"
+    show_null_points: true
+    interpolation: linear
     listen: {}
-    row: 21
-    col: 10
-    width: 14
-    height: 12
-  filters:
-  - name: Manager
-    title: Manager
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    model: sales_analytics
-    explore: opportunity
-    listens_to_filters: []
-    field: opportunity_owner.manager
-  - name: Business Segment
-    title: Business Segment
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    model: sales_analytics
-    explore: opportunity
-    listens_to_filters: []
-    field: account.business_segment
+    row: 11
+    col: 12
+    width: 12
+    height: 10


### PR DESCRIPTION
There wasn't a strong consensus regarding which dashboard filters we want on the `sales_leadership_overview` dashboard. The filters we had on the dash originally (Manager and Segment) were not really applicable to every tile, and so for the time, keeping the dashboard filter-less.