### PR TITLE
Updated Days to Close tile on "Lookup" dash

### DIFF
--- a/account_core.view.lkml
+++ b/account_core.view.lkml
@@ -1,7 +1,25 @@
 view: account_core {
   extends: [account_adapter]
 #   extension: required
+
+  # filters #
+  filter: account_select {
+    type: string
+    suggest_dimension: name
+  }
+
   # dimensions #
+
+  dimension: account_comparitor {
+    type: string
+    case: {
+      when: {
+        label: "Selected Account"
+        sql: {% condition account_select %} ${name} {% endcondition %};;
+      }
+      else: "All Other Accounts"
+    }
+  }
 
   dimension_group: _fivetran_synced { hidden: yes }
 

--- a/customer_lookup.dashboard.lookml
+++ b/customer_lookup.dashboard.lookml
@@ -419,8 +419,7 @@
     type: single_value
     fields: [opportunity.average_days_to_closed_won, account.account_comparitor]
     fill_fields: [account.account_comparitor]
-    filters:
-      account.account_select: Gladly
+    filters: {}
     sorts: [account.account_comparitor]
     limit: 500
     dynamic_fields: [{table_calculation: compared_to_avg, label: Compared to Avg,
@@ -439,7 +438,8 @@
     comparison_label: Days Compared to Avg
     series_types: {}
     hidden_fields: [account.name_comparitor, account.account_comparitor]
-    listen: {}
+    listen:
+      Account: account.account_select
     row: 0
     col: 12
     width: 6

--- a/customer_lookup.dashboard.lookml
+++ b/customer_lookup.dashboard.lookml
@@ -1,6 +1,6 @@
 - dashboard: customer_lookup
   title: Customer Lookup
-  extends: sales_analystics_base
+  layout: newspaper
   elements:
   - title: Account Name
     name: Account Name
@@ -417,13 +417,29 @@
     model: sales_analytics
     explore: opportunity
     type: single_value
-    fields: [opportunity.average_days_to_closed_won]
-    sorts: [opportunity.average_days_to_closed_won desc]
+    fields: [opportunity.average_days_to_closed_won, account.account_comparitor]
+    fill_fields: [account.account_comparitor]
+    filters:
+      account.account_select: Gladly
+    sorts: [account.account_comparitor]
     limit: 500
-    query_timezone: America/Los_Angeles
+    dynamic_fields: [{table_calculation: compared_to_avg, label: Compared to Avg,
+        expression: "${opportunity.average_days_to_closed_won} - offset(${opportunity.average_days_to_closed_won},1)",
+        value_format: !!null '', value_format_name: decimal_0, _kind_hint: measure,
+        _type_hint: number}]
+    query_timezone: UTC
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    value_format: "#"
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: true
+    show_comparison_label: true
+    comparison_label: Days Compared to Avg
     series_types: {}
-    listen:
-      Account: account.name
+    hidden_fields: [account.name_comparitor, account.account_comparitor]
+    listen: {}
     row: 0
     col: 12
     width: 6


### PR DESCRIPTION
We were seeing an error message on the comparison portion of the "Days to Close" tile on the `Lookup` Dashboard. Looks like a bug having to do with merge queries on LookML dashboards. In which case, opted to model out the logic (i.e. use a peer vs population pattern like in this discourse article below) to perform comparisons between a given account's days to close and the avg days to close of all other accounts:
https://discourse.looker.com/t/analytic-block-peer-comparison-compare-against-rest-of-population/1518