### PR TITLE
Update filter on Leaderboard (Total Revenue) Report

### DIFF
--- a/application.json
+++ b/application.json
@@ -248,7 +248,7 @@
               "model": "sales_analytics",
               "view": "opportunity"
             },
-            "field": "opportunity_owner.rep_filter",
+            "field": "opportunity_owner.name",
             "name": "Sales Rep",
             "type": "Select"
           }],


### PR DESCRIPTION
Previously used "rep_filter" field rather than "name", which led to no results popping up in the filter suggestions for the report