### PR TITLE
Adding a join to opportunity owner in the account explore 

### DIFF
--- a/account.explore.lkml
+++ b/account.explore.lkml
@@ -41,6 +41,12 @@ explore: account_core {
     relationship: one_to_many
   }
 
+  join: opportunity_owner {
+    from: user
+    sql_on: ${opportunity.owner_id} = ${opportunity_owner.id} ;;
+    relationship: many_to_one
+  }
+
   join: account_facts_start_date {
     sql_on: ${account_facts_start_date.account_id} = ${account.id} ;;
     relationship: one_to_one


### PR DESCRIPTION
This is so that we can join quota to opp owner in the config level explore. From there, we can reference quota.ae_segment in the user.ae_segment dimension, which will then be referenced in the filters on the Leaderboard report (and others)