### PR TITLE
Unhiding comparitor related fields in the user view for dev purposes

### DIFF
--- a/user_core.view.lkml
+++ b/user_core.view.lkml
@@ -3,26 +3,29 @@ view: user_core {
   extension: required
   # dimensions #
 
+  # Unhiding for dev purposes (for now)
   filter: name_select {
     suggest_dimension: opportunity_owner.name
-    hidden: yes
+    hidden: no
   }
 
-
+  # Unhiding for dev purposes (for now)
   filter: department_select {
     suggest_dimension: account.business_segment
-    hidden: yes
+    hidden: no
   }
 
+  # Unhiding for dev purposes (for now)
   filter: rep_filter {
     suggest_explore: opportunity
     suggest_dimension: opportunity_owner.name
-    hidden: yes
+    hidden: no
   }
 
+  # Unhiding for dev purposes (for now)
   measure: rep_highlight_acv {
     type: number
-    hidden: yes
+    hidden: no
     sql: CASE WHEN ${name} = {% parameter rep_filter %} THEN ${opportunity.total_closed_won_new_business_amount}
               ELSE NULL
               END


### PR DESCRIPTION
Been feeling a lot of dev pain from needing to unhide and then hide these fields (currently trying to deprecate the "rep_filter" field so that we only use "name_select" since these two filter-only fields are functionally the same). Specifically, feeling pain when trying to select fields in the dashboard filter UI (which doesn't reveal hidden fields).