### PR TITLE
Editing names on Reports

### DIFF
--- a/application.json
+++ b/application.json
@@ -163,7 +163,7 @@
       "navigation": {
         "sections": [
           {
-            "title": "Rep Performance",
+            "title": "",
             "key": "rep performance",
             "description": "",
             "items": [
@@ -204,7 +204,7 @@
       "navigation": {
         "sections": [
           {
-            "title": "Opportunities",
+            "title": "",
             "key": "opportunities",
             "description": "",
             "items": [
@@ -534,10 +534,13 @@
       "description": "Create your new opportunities using up-to-date lead information.",
       "filters": [
         {
+          "autoSuggest": {
+            "model": "sales_analytics",
+            "view": "lead"
+          },
           "field": "lead_owner.name",
-          "name": "Sales Rep",
-          "type": "Table",
-          "tableID": "sales_rep"
+          "name": "Lead Owner",
+          "type": "Select"
         }
       ],
       "lookCollection": {


### PR DESCRIPTION
1. Removed titles for "Rep Performance Reports" page and "Opportunity Reports" page (since we already see titles of reports landing pages at the top of the UI. Seeing titles twice is redundant.

2. Changed name and logic of filter for "Leads" report. 