### PR TITLE
Change tiles on Leadership Dash and Performance dash to use "last quarter" rather than "this quarter"

### DIFF
--- a/opportunity_history_waterfall_core.view.lkml
+++ b/opportunity_history_waterfall_core.view.lkml
@@ -839,7 +839,7 @@ view: opp_history_waterfall_derived {
       column: business_segment { field: account.business_segment }
       filters: {
         field: opportunity_history_waterfall.pipeline_dates
-        value: "this quarter"
+        value: "last quarter"
       }
     }
 

--- a/sales_leadership_overview.dashboard.lookml
+++ b/sales_leadership_overview.dashboard.lookml
@@ -2,47 +2,6 @@
   title: Sales Leadership Quarter Overview
   extends: sales_analytics_base
   elements:
-  - title: New Customers
-    name: New Customers
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields: [opportunity.count_new_business_won, opportunity.close_year]
-    pivots: [opportunity.close_year]
-    fill_fields: [opportunity.close_year]
-    filters:
-      opportunity.close_date: 0 quarters ago for 1 quarter, 4 quarters ago for 1 quarter
-      opportunity.type: New Business
-    sorts: [opportunity.close_year desc]
-    limit: 500
-    column_limit: 50
-    dynamic_fields: [{table_calculation: this_quarter, label: This Quarter, expression: 'pivot_index(${opportunity.count_new_business_won},
-          1)
-
-          ', value_format: !!null '', value_format_name: !!null '', _kind_hint: supermeasure,
-        _type_hint: number}, {table_calculation: change, label: Change, expression: "(pivot_index(${opportunity.count_new_business_won},\
-          \ 1) - pivot_index(${opportunity.count_new_business_won}, 2))/pivot_index(${opportunity.count_new_business_won},\
-          \ 2)", value_format: !!null '', value_format_name: percent_0, _kind_hint: supermeasure,
-        _type_hint: number}]
-    filter_expression: "((extract_years(now())=extract_years(${opportunity.close_year})\n\
-      \   AND ${opportunity.close_year} <= now())\n\nOR \n\n(((extract_years(now())-1)=extract_years(${opportunity.close_year})\n\
-      \  AND ${opportunity.close_year} <= add_years(-1,now()))\n\nAND\n\n(extract_months(${opportunity.close_date})\
-      \ = extract_months(now())\nAND\nextract_days(${opportunity.close_date}) <= extract_days(now()))\n\
-      \nOR\n\nextract_months(${opportunity.close_date}) < extract_months(now())))"
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: change
-    comparison_reverse_colors: false
-    show_comparison_label: false
-    font_size: small
-    hidden_fields: [opportunity.count_new_business_won]
-    listen: {}
-    row: 2
-    col: 18
-    width: 3
-    height: 4
   - title: Pipeline Forecast
     name: Pipeline Forecast
     model: sales_analytics
@@ -295,149 +254,47 @@
     col: 15
     width: 3
     height: 4
-  - title: Bookings By Business Segment
-    name: Bookings By Business Segment
+  - title: Bookings by Geography
+    name: Bookings by Geography
     model: sales_analytics
     explore: opportunity
-    type: looker_donut_multiples
-    fields: [account.business_segment, opportunity.total_closed_won_new_business_amount,
-      opportunity.close_year]
-    pivots: [account.business_segment]
-    fill_fields: [opportunity.close_year]
+    type: looker_map
+    fields: [account.billing_state, opportunity.total_closed_won_new_business_amount]
     filters:
-      account.business_segment: "-Unknown"
-      opportunity.close_quarter: this quarter, last year
-    sorts: [account.business_segment, account.business_segment__sort_, opportunity.close_year]
+      account.billing_country: USA,United States
+      opportunity.total_closed_won_new_business_amount: ">0"
+    sorts: [opportunity.total_closed_won_new_business_amount desc]
     limit: 500
-    column_limit: 50
-    row_total: right
-    show_value_labels: true
-    font_size: 25
-    hide_legend: false
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: a418cd33-fecf-4932-9933-dbd6652c610b
-      options:
-        steps: 5
-    series_colors:
-      Enterprise - 2 - opportunity.total_closed_won_new_business_amount: "#462c9d"
-      Mid-Market - 1 - opportunity.total_closed_won_new_business_amount: "#735eae"
-      Small Business - 0 - opportunity.total_closed_won_new_business_amount: "#9f92cb"
-    trellis: ''
-    stacking: normal
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: false
+    query_timezone: UTC
+    map_plot_mode: points
+    heatmap_gridlines: false
+    heatmap_gridlines_empty: false
+    heatmap_opacity: 0.5
+    show_region_field: true
+    draw_map_labels_above_data: true
+    map_tile_provider: light
+    map_position: custom
+    map_latitude: 38.89103282648846
+    map_longitude: -96.9291114807129
+    map_zoom: 4
+    map_scale_indicator: 'off'
+    map_pannable: false
+    map_zoomable: false
+    map_marker_type: circle
+    map_marker_icon_name: default
+    map_marker_radius_mode: proportional_value
+    map_marker_units: meters
+    map_marker_proportional_scale_type: linear
+    map_marker_color_mode: fixed
     show_view_names: false
-    point_style: none
-    limit_displayed_rows: false
-    y_axes: [{label: '', orientation: left, series: [{id: Small Business - 0 - opportunity.total_closed_won_new_business_amount,
-            name: Small Business, axisId: Small Business - 0 - opportunity.total_closed_won_new_business_amount},
-          {id: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount,
-            name: Mid-Market, axisId: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount},
-          {id: Enterprise - 2 - opportunity.total_closed_won_new_business_amount,
-            name: Enterprise, axisId: Enterprise - 2 - opportunity.total_closed_won_new_business_amount}],
-        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
-    y_axis_combined: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    y_axis_orientation: [left, right]
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: true
-    show_silhouette: false
-    totals_color: "#808080"
-    series_types: {}
-    listen: {}
-    row: 24
-    col: 0
-    width: 12
-    height: 6
-  - title: Bookings by Source
-    name: Bookings by Source
-    model: sales_analytics
-    explore: opportunity
-    type: looker_donut_multiples
-    fields: [opportunity.total_closed_won_new_business_amount, opportunity.close_year,
-      opportunity.source]
-    pivots: [opportunity.source]
-    fill_fields: [opportunity.close_year]
-    filters:
-      account.business_segment: "-Unknown"
-      opportunity.close_quarter: this quarter, last year
-    sorts: [opportunity.close_year, opportunity.source]
-    limit: 500
-    column_limit: 50
-    row_total: right
-    show_value_labels: true
-    font_size: 25
-    hide_legend: false
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      custom:
-        id: 2489d897-97ba-c479-3978-b11422ddc318
-        label: Custom
-        type: continuous
-        stops:
-        - color: "#f3dbe0"
-          offset: 0
-        - color: "#D978A1"
-          offset: 100
-      options:
-        steps: 5
-    series_colors: {}
-    trellis: ''
-    stacking: normal
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: false
-    show_view_names: false
-    point_style: none
-    limit_displayed_rows: false
-    y_axes: [{label: '', orientation: left, series: [{id: Small Business - 0 - opportunity.total_closed_won_new_business_amount,
-            name: Small Business, axisId: Small Business - 0 - opportunity.total_closed_won_new_business_amount},
-          {id: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount,
-            name: Mid-Market, axisId: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount},
-          {id: Enterprise - 2 - opportunity.total_closed_won_new_business_amount,
-            name: Enterprise, axisId: Enterprise - 2 - opportunity.total_closed_won_new_business_amount}],
-        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
-    y_axis_combined: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    y_axis_orientation: [left, right]
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: true
-    show_silhouette: false
-    totals_color: "#808080"
-    series_types: {}
-    listen: {}
-    row: 24
+    show_legend: true
+    map_value_colors: ["#170658", "#a49bc1"]
+    quantize_map_value_colors: false
+    reverse_map_value_colors: true
+    row: 11
     col: 12
     width: 12
-    height: 6
+    height: 13
   - title: Quota Attainment
     name: Quota Attainment
     model: sales_analytics
@@ -447,8 +304,8 @@
       opportunity.close_quarter, quota.quarterly_aggregate_quota_measure]
     pivots: [opportunity.close_quarter]
     filters:
-      opportunity.close_quarter: this quarter, last quarter, 4 quarters ago for 1
-        quarter
+      opportunity.close_quarter: last quarter, 2 quarters ago for 1 quarter, 5 quarters
+        ago for 1 quarter
       opportunity_owner.manager: ''
       account.business_segment: ''
     sorts: [opportunity.close_quarter desc, opportunity.day_of_quarter]
@@ -463,8 +320,8 @@
         _type_hint: number}, {table_calculation: goal, label: Goal, expression: 'if(mod(row(),2)
           = 0,pivot_where(pivot_column() = 1, 1)*0 + 1,null)', value_format: !!null '',
         value_format_name: !!null '', _kind_hint: supermeasure, _type_hint: number}]
-    trellis: ''
     stacking: ''
+    trellis: ''
     color_application:
       collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
       palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
@@ -482,15 +339,16 @@
       2019-01 - of_quota: This Quarter
       2018-10 - of_quota: Last Quarter
       2019-01 - percent_of_quota: This Quarter
-      2018-10 - percent_of_quota: Last Quarter
+      2018-10 - percent_of_quota: This Quarter
       2018-01 - percent_of_quota: This Quarter - Last Year
+      2018-07 - percent_of_quota: Last Quarter
+      2017-10 - percent_of_quota: This Quarter - Last Year
     series_types:
       goal: scatter
     series_point_styles: {}
     limit_displayed_rows: false
-    hidden_series: [2018-10 - calculation_5, 2018-07 - percent_of_quota, 2018-07 -
-        calculation_5, 2018-04 - calculation_5, 2018-01 - calculation_5, 2018-04 -
-        percent_of_quota]
+    hidden_series: [2018-10 - calculation_5, 2018-07 - calculation_5, 2018-04 - calculation_5,
+      2018-01 - calculation_5, 2018-04 - percent_of_quota]
     y_axes: [{label: '', orientation: left, series: [{id: 2019-01 - of_quota, name: This
               Quarter, axisId: of_quota}, {id: 2018-10 - of_quota, name: Last Quarter,
             axisId: of_quota}, {id: 2018-07 - of_quota, name: 2018-Q3 - % of Quota,
@@ -524,6 +382,81 @@
     col: 0
     width: 15
     height: 11
+  - title: New Bookings
+    name: New Bookings
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields: [opportunity.close_year, opportunity.total_closed_won_new_business_amount]
+    pivots: [opportunity.close_year]
+    fill_fields: [opportunity.close_year]
+    filters:
+      opportunity.close_date: last quarter, 5 quarters ago for 1 quarter
+      opportunity.type: "-Renewal"
+    sorts: [opportunity.close_year desc]
+    dynamic_fields: [{table_calculation: this_year, label: This Year, expression: 'pivot_index(${opportunity.total_closed_won_new_business_amount},
+          1) - pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)',
+        value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00', value_format_name: !!null '',
+        _kind_hint: supermeasure, _type_hint: number}, {table_calculation: change,
+        label: Change, expression: "\n(pivot_index(${opportunity.total_closed_won_new_business_amount},\
+          \ 1) - pivot_index(${opportunity.total_closed_won_new_business_amount},\
+          \ 2))/pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)",
+        value_format: !!null '', value_format_name: percent_0, _kind_hint: supermeasure,
+        _type_hint: number}]
+    color_application:
+      collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7
+      palette_id: fb7bb53e-b77b-4ab6-8274-9d420d3d73f3
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: false
+    font_size: medium
+    text_color: black
+    hidden_fields: [opportunity.total_closed_won_revenue, change]
+    listen: {}
+    row: 0
+    col: 15
+    width: 9
+    height: 2
+  - title: New Customers
+    name: New Customers
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields: [opportunity.count_new_business_won, opportunity.close_year]
+    pivots: [opportunity.close_year]
+    fill_fields: [opportunity.close_year]
+    filters:
+      opportunity.close_date: last quarter, 5 quarters ago for 1 quarter
+      opportunity.type: New Business
+    sorts: [opportunity.close_year desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields: [{table_calculation: this_quarter, label: This Quarter, expression: 'pivot_index(${opportunity.count_new_business_won},
+          1)
+
+          ', value_format: !!null '', value_format_name: !!null '', _kind_hint: supermeasure,
+        _type_hint: number}, {table_calculation: change, label: Change, expression: "(pivot_index(${opportunity.count_new_business_won},\
+          \ 1) - pivot_index(${opportunity.count_new_business_won}, 2))/pivot_index(${opportunity.count_new_business_won},\
+          \ 2)", value_format: !!null '', value_format_name: percent_0, _kind_hint: supermeasure,
+        _type_hint: number}]
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: false
+    font_size: small
+    hidden_fields: [opportunity.count_new_business_won]
+    listen: {}
+    row: 2
+    col: 18
+    width: 3
+    height: 4
   - title: of Quota
     name: of Quota
     model: sales_analytics
@@ -533,7 +466,7 @@
       quota.quarterly_aggregate_quota_measure]
     fill_fields: [opportunity.close_quarter]
     filters:
-      opportunity.close_year: this quarter,next quarter
+      opportunity.close_year: last quarter, this quarter
       opportunity_owner.manager: ''
       account.business_segment: ''
     sorts: [opportunity.close_quarter]
@@ -549,7 +482,8 @@
           of Days in the Quarter, expression: 'diff_days(${opportunity.close_quarter},offset(${opportunity.close_quarter},1))',
         value_format: !!null '', value_format_name: !!null '', _kind_hint: dimension,
         _type_hint: number}, {table_calculation: percent_of_the_way_through_the_quarter,
-        label: Percent of the way through the quarter, expression: "${current_day_of_the_quarter}/${number_of_days_in_the_quarter}",
+        label: Percent of the way through the quarter, expression: 'if(${current_day_of_the_quarter}/${number_of_days_in_the_quarter}
+          > 1, 1, ${current_day_of_the_quarter}/${number_of_days_in_the_quarter})',
         value_format: !!null '', value_format_name: percent_0, _kind_hint: dimension,
         _type_hint: number}]
     custom_color_enabled: true
@@ -570,68 +504,6 @@
     col: 21
     width: 3
     height: 4
-  - title: Rep Performance Overview
-    name: Rep Performance Overview
-    model: sales_analytics
-    explore: opportunity
-    type: table
-    fields: [opportunity_owner.name, opportunity_owner.tenure, opportunity_owner.title,
-      account_owner.manager, quota.quarterly_quota, opportunity.total_new_closed_won_amount_qtd,
-      opportunity.total_pipeline_amount]
-    filters:
-      opportunity_owner.is_sales_rep: 'Yes'
-      opportunity_owner.manager: ''
-      account.business_segment: ''
-    sorts: [to_quota desc]
-    limit: 500
-    column_limit: 50
-    dynamic_fields: [{table_calculation: closed_won, label: Closed Won, expression: "${opportunity.total_new_closed_won_amount_qtd}",
-        value_format: '[>=1000000]$0.0,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
-        _kind_hint: measure, _type_hint: number}, {table_calculation: to_quota, label: "%\
-          \ to Quota", expression: 'if(${opportunity.total_new_closed_won_amount_qtd}/${quota.quarterly_quota}
-          > 1, 1, ${opportunity.total_new_closed_won_amount_qtd}/${quota.quarterly_quota})',
-        value_format: !!null '', value_format_name: percent_0, _kind_hint: measure,
-        _type_hint: number}, {table_calculation: gap, label: Gap, expression: 'if((${quota.quarterly_quota}-${opportunity.total_new_closed_won_amount_qtd})>0,${quota.quarterly_quota}-${opportunity.total_new_closed_won_amount_qtd},0)',
-        value_format: '[>=1000000]$0.0,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
-        _kind_hint: measure, _type_hint: number}, {table_calculation: pipeline_acv,
-        label: Pipeline ACV, expression: "${opportunity.total_pipeline_amount}", value_format: '[>=1000000]$0.0,,"M";[>=1000]$0,"K";$0.00',
-        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}, {
-        table_calculation: coverage, label: Coverage, expression: 'if(${gap}=0, null,
-          ${opportunity.total_pipeline_amount}/${gap})', value_format: !!null '',
-        value_format_name: percent_0, _kind_hint: measure, _type_hint: number}]
-    query_timezone: America/Los_Angeles
-    color_application:
-      collection_id: legacy
-      palette_id: looker_classic
-    show_view_names: false
-    show_row_numbers: true
-    truncate_column_names: false
-    subtotals_at_bottom: false
-    hide_totals: false
-    hide_row_totals: false
-    series_labels:
-      opportunity.total_new_closed_won_amount_qtd: Closed Won
-      opportunity.total_pipeline_amount: Pipeline
-    table_theme: white
-    limit_displayed_rows: false
-    enable_conditional_formatting: true
-    conditional_formatting: [{type: along a scale..., value: !!null '', background_color: !!null '',
-        font_color: !!null '', color_application: {collection_id: legacy, palette_id: legacy_diverging1,
-          options: {steps: 5}}, bold: false, italic: false, strikethrough: false,
-        fields: [to_quota]}, {type: along a scale..., value: 1, background_color: !!null '',
-        font_color: !!null '', color_application: {collection_id: legacy, palette_id: legacy_diverging1,
-          options: {steps: 5, constraints: {max: {type: number, value: 0.1}, min: {
-                type: number, value: 0}, mid: {type: number, value: 0.5}}}}, bold: false,
-        italic: false, strikethrough: false, fields: [coverage]}]
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    series_types: {}
-    hidden_fields: [opportunity.total_new_closed_won_amount_qtd, opportunity.total_pipeline_amount]
-    listen: {}
-    row: 46
-    col: 0
-    width: 24
-    height: 10
   - title: Performance vs Quota (QTD)
     name: Performance vs Quota (QTD)
     model: sales_analytics
@@ -641,25 +513,25 @@
       quota.quarterly_aggregate_quota_measure]
     fill_fields: [opportunity.close_date]
     filters:
-      opportunity.close_year: this quarter
+      opportunity.close_year: last quarter
       opportunity_owner.manager: ''
       account.business_segment: ''
     sorts: [opportunity.close_date]
     limit: 1000
     column_limit: 50
     dynamic_fields: [{table_calculation: quota_per_day, label: Quota Per Day, expression: "${quota_as_table_calc}/count(row())",
-        value_format: !!null '', value_format_name: usd_0, _kind_hint: dimension,
-        _type_hint: number}, {table_calculation: grab_quota_value, label: Grab Quota
-          Value, expression: "# Used to account for the fact that the measure might\
-          \ be null for dates that are dimensino-filled in.\n# We take the max of\
-          \ an offset list of our quuarterly agg quota measure column, so as long\
-          \ as at least one row has a non-dimension filled close date, we can grab\
-          \ the quota value\n\nif(row() = 1, max(offset_list(${quota.quarterly_aggregate_quota_measure},0,91)),null)",
+        value_format: !!null '', value_format_name: usd_0, _kind_hint: measure, _type_hint: number},
+      {table_calculation: grab_quota_value, label: Grab Quota Value, expression: "#\
+          \ Used to account for the fact that the measure might be null for dates\
+          \ that are dimensino-filled in.\n# We take the max of an offset list of\
+          \ our quuarterly agg quota measure column, so as long as at least one row\
+          \ has a non-dimension filled close date, we can grab the quota value\n\n\
+          if(row() = 1, max(offset_list(${quota.quarterly_aggregate_quota_measure},0,91)),null)",
         value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
         _type_hint: number}, {table_calculation: quota_as_table_calc, label: Quota
           as Table Calc, expression: 'offset(${grab_quota_value},-1*(row()-1))', value_format: !!null '',
-        value_format_name: !!null '', _kind_hint: dimension, _type_hint: 'null'},
-      {table_calculation: cumulative_quota, label: Cumulative Quota, expression: 'running_total(${quota_per_day})
+        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}, {
+        table_calculation: cumulative_quota, label: Cumulative Quota, expression: 'running_total(${quota_per_day})
           + ${opportunity.total_closed_won_new_business_amount}*0', value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00',
         value_format_name: !!null '', _kind_hint: measure, _type_hint: number}, {
         table_calculation: cumulative_total_won, label: Cumulative Total Won, expression: 'running_total(${opportunity.total_closed_won_new_business_amount})',
@@ -729,91 +601,6 @@
     col: 15
     width: 9
     height: 5
-  - title: New Bookings
-    name: New Bookings
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields: [opportunity.close_year, opportunity.total_closed_won_new_business_amount]
-    pivots: [opportunity.close_year]
-    fill_fields: [opportunity.close_year]
-    filters:
-      opportunity.close_date: 0 quarters ago for 1 quarter, 4 quarters ago for 1 quarter
-      opportunity.type: "-Renewal"
-    sorts: [opportunity.close_year desc]
-    dynamic_fields: [{table_calculation: this_year, label: This Year, expression: 'pivot_index(${opportunity.total_closed_won_new_business_amount},
-          1) - pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)',
-        value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00', value_format_name: !!null '',
-        _kind_hint: supermeasure, _type_hint: number}, {table_calculation: change,
-        label: Change, expression: "\n(pivot_index(${opportunity.total_closed_won_new_business_amount},\
-          \ 1) - pivot_index(${opportunity.total_closed_won_new_business_amount},\
-          \ 2))/pivot_index(${opportunity.total_closed_won_new_business_amount}, 2)",
-        value_format: !!null '', value_format_name: percent_0, _kind_hint: supermeasure,
-        _type_hint: number}]
-    filter_expression: "((extract_years(now())=extract_years(${opportunity.close_year})\n\
-      \   AND ${opportunity.close_year} <= now())\n\nOR \n\n(((extract_years(now())-1)=extract_years(${opportunity.close_year})\n\
-      \  AND ${opportunity.close_year} <= add_years(-1,now()))\n\nAND\n\n(extract_months(${opportunity.close_date})\
-      \ = extract_months(now())\nAND\nextract_days(${opportunity.close_date}) <= extract_days(now()))\n\
-      \nOR\n\nextract_months(${opportunity.close_date}) < extract_months(now())))"
-    color_application:
-      collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7
-      palette_id: fb7bb53e-b77b-4ab6-8274-9d420d3d73f3
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: change
-    comparison_reverse_colors: false
-    show_comparison_label: false
-    font_size: medium
-    text_color: black
-    hidden_fields: [opportunity.total_closed_won_revenue, change]
-    listen: {}
-    row: 0
-    col: 15
-    width: 9
-    height: 2
-  - title: Bookings by Geography
-    name: Bookings by Geography
-    model: sales_analytics
-    explore: opportunity
-    type: looker_map
-    fields: [account.billing_state, opportunity.total_closed_won_new_business_amount]
-    filters:
-      account.billing_country: USA,United States
-      opportunity.total_closed_won_new_business_amount: ">0"
-    sorts: [opportunity.total_closed_won_new_business_amount desc]
-    limit: 500
-    query_timezone: UTC
-    map_plot_mode: points
-    heatmap_gridlines: false
-    heatmap_gridlines_empty: false
-    heatmap_opacity: 0.5
-    show_region_field: true
-    draw_map_labels_above_data: true
-    map_tile_provider: light
-    map_position: custom
-    map_latitude: 38.89103282648846
-    map_longitude: -96.9291114807129
-    map_zoom: 4
-    map_scale_indicator: 'off'
-    map_pannable: false
-    map_zoomable: false
-    map_marker_type: circle
-    map_marker_icon_name: default
-    map_marker_radius_mode: proportional_value
-    map_marker_units: meters
-    map_marker_proportional_scale_type: linear
-    map_marker_color_mode: fixed
-    show_view_names: false
-    show_legend: true
-    map_value_colors: ["#170658", "#a49bc1"]
-    quantize_map_value_colors: false
-    reverse_map_value_colors: true
-    row: 11
-    col: 12
-    width: 12
-    height: 13
   - title: Funnel
     name: Funnel
     model: sales_analytics
@@ -822,7 +609,7 @@
     fields: [opportunity_stage_history.stage, opportunity_stage_history.opps_in_each_stage]
     filters:
       opportunity_stage_history.stage: "-NULL"
-      opportunity.close_date: 0 quarters ago for 4 quarters
+      opportunity.close_date: last quarter
     sorts: [opportunity_stage_history.opps_in_each_stage desc]
     limit: 500
     query_timezone: America/Los_Angeles
@@ -860,3 +647,208 @@
     col: 0
     width: 12
     height: 13
+  - title: Bookings By Business Segment
+    name: Bookings By Business Segment
+    model: sales_analytics
+    explore: opportunity
+    type: looker_donut_multiples
+    fields: [account.business_segment, opportunity.total_closed_won_new_business_amount,
+      opportunity.close_year]
+    pivots: [account.business_segment]
+    fill_fields: [opportunity.close_year]
+    filters:
+      account.business_segment: "-Unknown"
+      opportunity.close_quarter: last quarter, 5 quarters ago for 1 quarter
+    sorts: [account.business_segment, account.business_segment__sort_, opportunity.close_year]
+    limit: 500
+    column_limit: 50
+    row_total: right
+    show_value_labels: true
+    font_size: 25
+    hide_legend: false
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: a418cd33-fecf-4932-9933-dbd6652c610b
+      options:
+        steps: 5
+    series_colors:
+      Enterprise - 2 - opportunity.total_closed_won_new_business_amount: "#462c9d"
+      Mid-Market - 1 - opportunity.total_closed_won_new_business_amount: "#735eae"
+      Small Business - 0 - opportunity.total_closed_won_new_business_amount: "#9f92cb"
+    trellis: ''
+    stacking: normal
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: false
+    show_view_names: false
+    point_style: none
+    limit_displayed_rows: false
+    y_axes: [{label: '', orientation: left, series: [{id: Small Business - 0 - opportunity.total_closed_won_new_business_amount,
+            name: Small Business, axisId: Small Business - 0 - opportunity.total_closed_won_new_business_amount},
+          {id: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount,
+            name: Mid-Market, axisId: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount},
+          {id: Enterprise - 2 - opportunity.total_closed_won_new_business_amount,
+            name: Enterprise, axisId: Enterprise - 2 - opportunity.total_closed_won_new_business_amount}],
+        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    y_axis_combined: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    y_axis_orientation: [left, right]
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: true
+    show_silhouette: false
+    totals_color: "#808080"
+    series_types: {}
+    listen: {}
+    row: 24
+    col: 0
+    width: 12
+    height: 6
+  - title: Bookings by Source
+    name: Bookings by Source
+    model: sales_analytics
+    explore: opportunity
+    type: looker_donut_multiples
+    fields: [opportunity.total_closed_won_new_business_amount, opportunity.close_year,
+      opportunity.source]
+    pivots: [opportunity.source]
+    fill_fields: [opportunity.close_year]
+    filters:
+      account.business_segment: "-Unknown"
+      opportunity.close_quarter: last quarter, 5 quarters ago for 1 quarter
+    sorts: [opportunity.close_year, opportunity.source]
+    limit: 500
+    column_limit: 50
+    row_total: right
+    show_value_labels: true
+    font_size: 25
+    hide_legend: false
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      custom:
+        id: 2489d897-97ba-c479-3978-b11422ddc318
+        label: Custom
+        type: continuous
+        stops:
+        - color: "#f3dbe0"
+          offset: 0
+        - color: "#D978A1"
+          offset: 100
+      options:
+        steps: 5
+    series_colors: {}
+    trellis: ''
+    stacking: normal
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: false
+    show_view_names: false
+    point_style: none
+    limit_displayed_rows: false
+    y_axes: [{label: '', orientation: left, series: [{id: Small Business - 0 - opportunity.total_closed_won_new_business_amount,
+            name: Small Business, axisId: Small Business - 0 - opportunity.total_closed_won_new_business_amount},
+          {id: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount,
+            name: Mid-Market, axisId: Mid-Market - 1 - opportunity.total_closed_won_new_business_amount},
+          {id: Enterprise - 2 - opportunity.total_closed_won_new_business_amount,
+            name: Enterprise, axisId: Enterprise - 2 - opportunity.total_closed_won_new_business_amount}],
+        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    y_axis_combined: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    y_axis_orientation: [left, right]
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: true
+    show_silhouette: false
+    totals_color: "#808080"
+    series_types: {}
+    listen: {}
+    row: 24
+    col: 12
+    width: 12
+    height: 6
+  - title: Rep Performance Overview
+    name: Rep Performance Overview
+    model: sales_analytics
+    explore: opportunity
+    type: table
+    fields: [opportunity_owner.name, opportunity_owner.tenure, opportunity_owner.title,
+      account_owner.manager, quota.quarterly_quota, opportunity.total_closed_won_new_business_amount,
+      opportunity.total_pipeline_amount]
+    filters:
+      opportunity_owner.is_sales_rep: 'Yes'
+      account.business_segment: ''
+      opportunity.close_date: last quarter
+    sorts: [to_quota desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields: [{table_calculation: closed_won, label: Closed Won, expression: "${opportunity.total_closed_won_new_business_amount}",
+        value_format: '[>=1000000]$0.0,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
+        _kind_hint: measure, _type_hint: number}, {table_calculation: to_quota, label: "%\
+          \ to Quota", expression: "${opportunity.total_closed_won_new_business_amount}/${quota.quarterly_quota}",
+        value_format: !!null '', value_format_name: percent_0, _kind_hint: measure,
+        _type_hint: number}, {table_calculation: gap, label: Gap, expression: 'if((${quota.quarterly_quota}-${opportunity.total_closed_won_new_business_amount})>0,${quota.quarterly_quota}-${opportunity.total_closed_won_new_business_amount},0)',
+        value_format: '[>=1000000]$0.0,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
+        _kind_hint: measure, _type_hint: number}, {table_calculation: pipeline_acv,
+        label: Pipeline ACV, expression: "${opportunity.total_pipeline_amount}", value_format: '[>=1000000]$0.0,,"M";[>=1000]$0,"K";$0.00',
+        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}, {
+        table_calculation: coverage, label: Coverage, expression: 'if(${gap}=0, null,
+          ${opportunity.total_pipeline_amount}/${gap})', value_format: !!null '',
+        value_format_name: percent_0, _kind_hint: measure, _type_hint: number}]
+    query_timezone: America/Los_Angeles
+    color_application:
+      collection_id: legacy
+      palette_id: looker_classic
+    show_view_names: false
+    show_row_numbers: true
+    truncate_column_names: false
+    subtotals_at_bottom: false
+    hide_totals: false
+    hide_row_totals: false
+    series_labels:
+      opportunity.total_new_closed_won_amount_qtd: Closed Won
+      opportunity.total_pipeline_amount: Pipeline
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: true
+    conditional_formatting: [{type: along a scale..., value: !!null '', background_color: !!null '',
+        font_color: !!null '', color_application: {collection_id: legacy, palette_id: legacy_diverging1,
+          options: {steps: 5, constraints: {max: {type: number, value: 1}, min: {
+                type: number, value: 0}}}}, bold: false, italic: false, strikethrough: false,
+        fields: [to_quota]}, {type: along a scale..., value: 1, background_color: !!null '',
+        font_color: !!null '', color_application: {collection_id: legacy, palette_id: legacy_diverging1,
+          options: {steps: 5, constraints: {max: {type: number, value: 0.1}, min: {
+                type: number, value: 0}, mid: {type: number, value: 0.5}}}}, bold: false,
+        italic: false, strikethrough: false, fields: [coverage]}]
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    series_types: {}
+    hidden_fields: [opportunity.total_pipeline_amount]
+    listen: {}
+    row: 46
+    col: 0
+    width: 24
+    height: 10

--- a/sales_rep_performance.dashboard.lookml
+++ b/sales_rep_performance.dashboard.lookml
@@ -3,33 +3,6 @@
   extends: sales_analytics_base
   query_timezone: query_saved
   elements:
-  - title: Revenue (QTD)
-    name: Revenue (QTD)
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields: [opportunity.total_closed_won_new_business_amount, quota.quarterly_quota]
-    filters:
-      opportunity.close_date: this quarter
-    sorts: [opportunity.total_closed_won_new_business_amount desc]
-    limit: 500
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: progress_percentage
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    comparison_label: Quota
-    font_size: small
-    series_types: {}
-    hidden_fields: []
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 0
-    width: 4
-    height: 4
   - title: Rep Name
     name: Rep Name
     model: sales_analytics
@@ -167,123 +140,6 @@
     col: 17
     width: 7
     height: 9
-  - title: "% to Quota (QoQ)"
-    name: "% to Quota (QoQ)"
-    model: sales_analytics
-    explore: opportunity
-    type: looker_column
-    fields: [opportunity.close_quarter, opportunity.total_closed_won_amount, quota.quarterly_quota]
-    filters:
-      opportunity.close_date: 8 quarters
-    sorts: [opportunity.close_quarter]
-    limit: 500
-    column_limit: 50
-    total: true
-    dynamic_fields: [{table_calculation: gap, label: Gap, expression: "${quota.quarterly_quota}-${opportunity.total_closed_won_amount}",
-        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
-        _type_hint: number}, {table_calculation: won, label: Won, expression: 'if(
-          is_null(${over}),${quota}-${under},${quota})', value_format: !!null '',
-        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}, {
-        table_calculation: over, label: Over, expression: 'if(${gap}<0,abs(${gap}),null)',
-        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
-        _type_hint: number}, {table_calculation: under, label: Under, expression: 'if(${gap}>0,abs(${gap}),null)',
-        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
-        _type_hint: number}, {table_calculation: quota, label: Quota, expression: "${quota.quarterly_quota}+${opportunity.total_closed_won_amount}*0",
-        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
-        _type_hint: number}]
-    stacking: normal
-    trellis: ''
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
-      options:
-        steps: 5
-    show_value_labels: false
-    label_density: 25
-    font_size: small
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    point_style: circle
-    series_colors:
-      won: "#ede8ff"
-      over: "#462C9D"
-      under: "#87898f"
-    series_types:
-      calculation_3: line
-      of_quota_met: line
-      quota_measure: line
-      quota: line
-    series_point_styles:
-      quota_measure: square
-    limit_displayed_rows: false
-    y_axes: [{label: '', orientation: left, series: [{id: won, name: Won, axisId: won},
-          {id: over, name: Over, axisId: over}, {id: under, name: Under, axisId: under},
-          {id: quota, name: Quota, axisId: quota}], showLabels: false, showValues: false,
-        unpinAxis: false, tickDensity: default, type: linear}, {label: '', orientation: left,
-        series: [{id: of_quota_met, name: "% of Quota Met", axisId: of_quota_met}],
-        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        type: linear}]
-    y_axis_combined: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: false
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    label_value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00'
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    reference_lines: []
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: true
-    show_silhouette: false
-    totals_color: "#808080"
-    hidden_fields: [opportunity.total_closed_won_revenue, quota_numbers.quarterly_quota,
-      gap, opportunity.total_closed_won_amount, quota.quarterly_quota]
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 12
-    width: 12
-    height: 8
-  - title: Pipeline (QTD)
-    name: Pipeline (QTD)
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields: [opportunity.total_pipeline_new_business_amount, opportunity.total_closed_won_new_business_amount,
-      quota.quarterly_quota, opportunity_owner.name]
-    filters:
-      opportunity.close_date: this year
-    sorts: [opportunity.total_pipeline_new_business_amount desc]
-    limit: 500
-    dynamic_fields: [{table_calculation: gap, label: Gap, expression: 'if((${quota.quarterly_quota}
-          - ${opportunity.total_closed_won_new_business_amount}) < 0,"Quota Reached,
-          No",to_string(${quota.quarterly_quota} - ${opportunity.total_closed_won_new_business_amount}))',
-        value_format: '[>=1000000]$0.00,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
-        _kind_hint: measure, _type_hint: string}]
-    custom_color_enabled: true
-    custom_color: ''
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: progress_percentage
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    comparison_label: Gap
-    show_view_names: 'true'
-    hidden_fields: [opportunity.total_closed_won_new_business_amount]
-    listen:
-      Sales Rep: opportunity_owner.name
-    row: 2
-    col: 4
-    width: 4
-    height: 4
   - title: Lifetime Bookings
     name: Lifetime Bookings
     model: sales_analytics
@@ -387,79 +243,6 @@
     listen:
       Sales Rep: opportunity_owner.name
     row: 6
-    col: 0
-    width: 4
-    height: 4
-  - title: Rank (QTD)
-    name: Rank (QTD)
-    model: sales_analytics
-    explore: opportunity
-    type: single_value
-    fields: [opportunity_owner.name, opportunity.total_closed_won_new_business_amount,
-      opportunity_owner.rep_highlight_acv]
-    filters:
-      opportunity_owner.name: "-NULL"
-      opportunity.close_date: this quarter
-    sorts: [opportunity.total_closed_won_new_business_amount desc]
-    limit: 500
-    column_limit: 50
-    dynamic_fields: [{table_calculation: rank, label: Rank, expression: 'if(NOT is_null(${opportunity_owner.rep_highlight_acv}),row(),
-          null)', value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
-        _type_hint: number}, {table_calculation: format, label: Format, expression: "concat(\n\
-          \tto_string(max(${rank})), \n  \n\n  if(\n  \tmod(max(${rank}),100) > 10\
-          \ AND mod(max(${rank}),100) <= 20, \n  \t\t\"th\", \n  \t\tif(mod(max(${rank}),10)\
-          \ = 1, \"st\", if(mod(max(${rank}),10) = 2, \n  \t\t\t\"nd\", \n  \t\t\t\
-          if(mod(max(${rank}),10) = 3, \"rd\", \"th\")\n  \t\t\t)\n  \t\t)\n  \t)\n\
-          )", value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
-        _type_hint: string}]
-    query_timezone: America/Los_Angeles
-    trellis: ''
-    stacking: normal
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
-      options:
-        steps: 5
-    show_value_labels: false
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: false
-    show_view_names: false
-    point_style: none
-    series_colors:
-      opportunity.average_amount_won: "#EE9093"
-      all_others: "#ede8ff"
-    series_types: {}
-    limit_displayed_rows: false
-    y_axes: [{label: '', orientation: left, series: [{id: opportunity.total_closed_won_new_business_amount,
-            name: 'Closed Won ACV ', axisId: opportunity.total_closed_won_new_business_amount}],
-        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
-        type: linear}]
-    y_axis_combined: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: false
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: true
-    show_silhouette: false
-    totals_color: "#462C9D"
-    show_null_points: true
-    interpolation: linear
-    hidden_fields: [opportunity.total_closed_won_new_business_amount, opportunity_owner.rep_highlight_acv,
-      rank]
-    listen:
-      Sales Rep: opportunity_owner.name_select
-    row: 10
     col: 0
     width: 4
     height: 4
@@ -604,6 +387,366 @@
     col: 14
     width: 10
     height: 8
+  - title: Stage Conversion Rates
+    name: Stage Conversion Rates
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields: [segment_lookup.grouping, opportunity_stage_history.stage, opportunity_stage_history.opps_in_each_stage]
+    pivots: [segment_lookup.grouping]
+    filters:
+      opportunity.is_renewal_upsell: 'No'
+    sorts: [segment_lookup.grouping, opportunity_stage_history.opps_in_each_stage
+        desc 0]
+    limit: 3
+    dynamic_fields: [{table_calculation: conversion_rates, label: Conversion Rates,
+        expression: "${opportunity_stage_history.opps_in_each_stage}/ offset(${opportunity_stage_history.opps_in_each_stage},\
+          \ -1)", value_format: !!null '', value_format_name: percent_0, _kind_hint: measure,
+        _type_hint: number}]
+    query_timezone: America/Los_Angeles
+    stacking: ''
+    trellis: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: 04e6ee8f-6a09-4649-891f-5bc66082e506
+      options:
+        steps: 5
+        reverse: false
+    show_value_labels: true
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: false
+    show_view_names: false
+    point_style: none
+    series_colors: {}
+    limit_displayed_rows: true
+    limit_displayed_rows_values:
+      show_hide: hide
+      first_last: first
+      num_rows: '1'
+    y_axes: [{label: '', orientation: left, series: [{id: Kevin Heller - 1 - conversion_rates,
+            name: Kevin Heller, axisId: conversion_rates}, {id: Rest of Named Accounts
+              - 2 - conversion_rates, name: Rest of Named Accounts, axisId: conversion_rates},
+          {id: Rest of Company - 3 - conversion_rates, name: Rest of Company, axisId: conversion_rates}],
+        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
+        type: linear}]
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    hidden_fields: [opportunity_stage_history.opps_in_each_stage]
+    listen:
+      Sales Rep: opportunity_owner.name_select
+    row: 18
+    col: 0
+    width: 12
+    height: 8
+  - title: Revenue for Each Stage
+    name: Revenue for Each Stage
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields: [segment_lookup.grouping, opportunity.average_new_deal_size, opportunity_stage_history.stage]
+    pivots: [segment_lookup.grouping]
+    filters:
+      opportunity_stage_history.stage: "-NULL"
+    sorts: [segment_lookup.grouping 0, opportunity_stage_history.stage]
+    limit: 500
+    column_limit: 3
+    dynamic_fields: [{table_calculation: avg_new_deal_size, label: Avg New Deal Size,
+        expression: 'if(is_null(${opportunity.average_new_deal_size}),0,${opportunity.average_new_deal_size})',
+        value_format: '[>=1000000]$0.00,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
+        _kind_hint: measure, _type_hint: number}]
+    query_timezone: UTC
+    stacking: ''
+    trellis: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      custom:
+        id: 3d22e0c3-cdc8-5f98-a391-a8a6410a165e
+        label: Custom
+        type: discrete
+        colors:
+        - "#BB55B4"
+        - "#8643B1"
+        - "#462C9D"
+      options:
+        steps: 5
+        reverse: false
+    show_value_labels: true
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: false
+    show_view_names: false
+    point_style: none
+    series_colors:
+      Kevin Heller - 1 - avg_new_deal_size: "#9f92cb"
+      Rest of Named Accounts - 2 - avg_new_deal_size: "#735eae"
+      Rest of Company - 3 - avg_new_deal_size: "#462c9d"
+    series_types: {}
+    limit_displayed_rows: false
+    y_axes: [{label: '', orientation: left, series: [{id: Henry Crawford - 1 - avg_new_deal_size,
+            name: Henry Crawford, axisId: avg_new_deal_size}, {id: Jeff De La Cruz
+              - 1 - avg_new_deal_size, name: Jeff De La Cruz, axisId: avg_new_deal_size},
+          {id: Jean Louise Manalo - 1 - avg_new_deal_size, name: Jean Louise Manalo,
+            axisId: avg_new_deal_size}], showLabels: false, showValues: false, unpinAxis: false,
+        tickDensity: default, type: linear}]
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    hidden_fields: [opportunity.average_new_deal_size]
+    listen:
+      Sales Rep: opportunity_owner.name_select
+    row: 18
+    col: 12
+    width: 12
+    height: 8
+  - title: Revenue (QTD)
+    name: Revenue (QTD)
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields: [opportunity.total_closed_won_new_business_amount, quota.quarterly_quota]
+    filters:
+      opportunity.close_date: last quarter
+    sorts: [opportunity.total_closed_won_new_business_amount desc]
+    limit: 500
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    show_comparison: true
+    comparison_type: progress_percentage
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    comparison_label: Quota
+    font_size: small
+    series_types: {}
+    hidden_fields: []
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 0
+    width: 4
+    height: 4
+  - title: Pipeline (QTD)
+    name: Pipeline (QTD)
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields: [opportunity.total_pipeline_new_business_amount, opportunity.total_closed_won_new_business_amount,
+      quota.quarterly_quota, opportunity_owner.name]
+    filters:
+      opportunity.close_date: last quarter
+    sorts: [opportunity.total_pipeline_new_business_amount desc]
+    limit: 500
+    dynamic_fields: [{table_calculation: gap, label: Gap, expression: 'if((${quota.quarterly_quota}
+          - ${opportunity.total_closed_won_new_business_amount}) < 0,"Quota Reached,
+          No",to_string(${quota.quarterly_quota} - ${opportunity.total_closed_won_new_business_amount}))',
+        value_format: '[>=1000000]$0.00,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
+        _kind_hint: measure, _type_hint: string}]
+    custom_color_enabled: true
+    custom_color: ''
+    show_single_value_title: true
+    show_comparison: true
+    comparison_type: progress_percentage
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    comparison_label: Gap
+    show_view_names: 'true'
+    hidden_fields: [opportunity.total_closed_won_new_business_amount]
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 4
+    width: 4
+    height: 4
+  - title: "% to Quota (QoQ)"
+    name: "% to Quota (QoQ)"
+    model: sales_analytics
+    explore: opportunity
+    type: looker_column
+    fields: [opportunity.close_quarter, opportunity.total_closed_won_amount, quota.quarterly_quota]
+    filters:
+      opportunity.close_date: 8 quarters ago for 8 quarters
+    sorts: [opportunity.close_quarter]
+    limit: 500
+    column_limit: 50
+    total: true
+    dynamic_fields: [{table_calculation: gap, label: Gap, expression: "${quota.quarterly_quota}-${opportunity.total_closed_won_amount}",
+        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
+        _type_hint: number}, {table_calculation: won, label: Won, expression: 'if(
+          is_null(${over}),${quota}-${under},${quota})', value_format: !!null '',
+        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}, {
+        table_calculation: over, label: Over, expression: 'if(${gap}<0,abs(${gap}),null)',
+        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
+        _type_hint: number}, {table_calculation: under, label: Under, expression: 'if(${gap}>0,abs(${gap}),null)',
+        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
+        _type_hint: number}, {table_calculation: quota, label: Quota, expression: "${quota.quarterly_quota}+${opportunity.total_closed_won_amount}*0",
+        value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
+        _type_hint: number}]
+    stacking: normal
+    trellis: ''
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
+      options:
+        steps: 5
+    show_value_labels: false
+    label_density: 25
+    font_size: small
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    point_style: circle
+    series_colors:
+      won: "#ede8ff"
+      over: "#462C9D"
+      under: "#87898f"
+    series_types:
+      calculation_3: line
+      of_quota_met: line
+      quota_measure: line
+      quota: line
+    series_point_styles:
+      quota_measure: square
+    limit_displayed_rows: false
+    y_axes: [{label: '', orientation: left, series: [{id: won, name: Won, axisId: won},
+          {id: over, name: Over, axisId: over}, {id: under, name: Under, axisId: under},
+          {id: quota, name: Quota, axisId: quota}], showLabels: false, showValues: false,
+        unpinAxis: false, tickDensity: default, type: linear}, {label: '', orientation: left,
+        series: [{id: of_quota_met, name: "% of Quota Met", axisId: of_quota_met}],
+        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        type: linear}]
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    label_value_format: '[>=1000000]$0.00,,"M";[>=1000]$0.00,"K";$0.00'
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    reference_lines: []
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: true
+    show_silhouette: false
+    totals_color: "#808080"
+    hidden_fields: [opportunity.total_closed_won_revenue, quota_numbers.quarterly_quota,
+      gap, opportunity.total_closed_won_amount, quota.quarterly_quota]
+    listen:
+      Sales Rep: opportunity_owner.name
+    row: 2
+    col: 12
+    width: 12
+    height: 8
+  - title: Rank (QTD)
+    name: Rank (QTD)
+    model: sales_analytics
+    explore: opportunity
+    type: single_value
+    fields: [opportunity_owner.name, opportunity.total_closed_won_new_business_amount,
+      opportunity_owner.rep_highlight_acv]
+    filters:
+      opportunity_owner.name: "-NULL"
+      opportunity.close_date: last quarter
+    sorts: [opportunity.total_closed_won_new_business_amount desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields: [{table_calculation: rank, label: Rank, expression: 'if(NOT is_null(${opportunity_owner.rep_highlight_acv}),row(),
+          null)', value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
+        _type_hint: number}, {table_calculation: format, label: Format, expression: "concat(\n\
+          \tto_string(max(${rank})), \n  \n\n  if(\n  \tmod(max(${rank}),100) > 10\
+          \ AND mod(max(${rank}),100) <= 20, \n  \t\t\"th\", \n  \t\tif(mod(max(${rank}),10)\
+          \ = 1, \"st\", if(mod(max(${rank}),10) = 2, \n  \t\t\t\"nd\", \n  \t\t\t\
+          if(mod(max(${rank}),10) = 3, \"rd\", \"th\")\n  \t\t\t)\n  \t\t)\n  \t)\n\
+          )", value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
+        _type_hint: string}]
+    query_timezone: America/Los_Angeles
+    trellis: ''
+    stacking: normal
+    color_application:
+      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
+      palette_id: be92eae7-de25-46ae-8e4f-21cb0b69a1f3
+      options:
+        steps: 5
+    show_value_labels: false
+    label_density: 25
+    legend_position: center
+    x_axis_gridlines: false
+    y_axis_gridlines: false
+    show_view_names: false
+    point_style: none
+    series_colors:
+      opportunity.average_amount_won: "#EE9093"
+      all_others: "#ede8ff"
+    series_types: {}
+    limit_displayed_rows: false
+    y_axes: [{label: '', orientation: left, series: [{id: opportunity.total_closed_won_new_business_amount,
+            name: 'Closed Won ACV ', axisId: opportunity.total_closed_won_new_business_amount}],
+        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
+        type: linear}]
+    y_axis_combined: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    x_axis_scale: auto
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: true
+    show_silhouette: false
+    totals_color: "#462C9D"
+    show_null_points: true
+    interpolation: linear
+    hidden_fields: [opportunity.total_closed_won_new_business_amount, opportunity_owner.rep_highlight_acv,
+      rank]
+    listen:
+      Sales Rep: opportunity_owner.name_select
+    row: 10
+    col: 0
+    width: 4
+    height: 4
   - title: Quarter Leaderboard
     name: Quarter Leaderboard
     model: sales_analytics
@@ -612,7 +755,7 @@
     fields: [opportunity_owner.name, opportunity.total_closed_won_new_business_amount,
       opportunity_owner.rep_highlight_acv]
     filters:
-      opportunity.close_date: this quarter
+      opportunity.close_date: last quarter
       opportunity_owner.name: "-NULL"
     sorts: [opportunity.total_closed_won_new_business_amount desc]
     limit: 15
@@ -673,149 +816,6 @@
     row: 10
     col: 4
     width: 10
-    height: 8
-  - title: Revenue for Each Stage
-    name: Revenue for Each Stage
-    model: sales_analytics
-    explore: opportunity
-    type: looker_column
-    fields: [segment_lookup.grouping, opportunity.average_new_deal_size, opportunity_stage_history.stage]
-    pivots: [segment_lookup.grouping]
-    filters:
-      opportunity_stage_history.stage: "-NULL"
-    sorts: [segment_lookup.grouping 0, opportunity_stage_history.stage]
-    limit: 500
-    column_limit: 3
-    dynamic_fields: [{table_calculation: avg_new_deal_size, label: Avg New Deal Size,
-        expression: 'if(is_null(${opportunity.average_new_deal_size}),0,${opportunity.average_new_deal_size})',
-        value_format: '[>=1000000]$0.00,,"M";[>=1000]$0,"K";$0.00', value_format_name: !!null '',
-        _kind_hint: measure, _type_hint: number}]
-    query_timezone: UTC
-    stacking: ''
-    trellis: ''
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      custom:
-        id: 3d22e0c3-cdc8-5f98-a391-a8a6410a165e
-        label: Custom
-        type: discrete
-        colors:
-        - "#BB55B4"
-        - "#8643B1"
-        - "#462C9D"
-      options:
-        steps: 5
-        reverse: false
-    show_value_labels: true
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: false
-    show_view_names: false
-    point_style: none
-    series_colors:
-      Kevin Heller - 1 - avg_new_deal_size: "#9f92cb"
-      Rest of Named Accounts - 2 - avg_new_deal_size: "#735eae"
-      Rest of Company - 3 - avg_new_deal_size: "#462c9d"
-    series_types: {}
-    limit_displayed_rows: false
-    y_axes: [{label: '', orientation: left, series: [{id: Kevin Heller - 1 - avg_new_deal_size,
-            name: Kevin Heller, axisId: avg_new_deal_size}, {id: Rest of Named Accounts
-              - 2 - avg_new_deal_size, name: Rest of Named Accounts, axisId: avg_new_deal_size},
-          {id: Rest of Company - 3 - avg_new_deal_size, name: Rest of Company, axisId: avg_new_deal_size}],
-        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
-        type: linear}]
-    y_axis_combined: true
-    show_y_axis_labels: false
-    show_y_axis_ticks: false
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: false
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    hidden_fields: [opportunity.average_new_deal_size]
-    listen:
-      Sales Rep: opportunity_owner.name_select
-    row: 18
-    col: 12
-    width: 12
-    height: 8
-  - title: Stage Conversion Rates
-    name: Stage Conversion Rates
-    model: sales_analytics
-    explore: opportunity
-    type: looker_column
-    fields: [segment_lookup.grouping, opportunity_stage_history.stage, opportunity_stage_history.opps_in_each_stage]
-    pivots: [segment_lookup.grouping]
-    filters:
-      opportunity.is_renewal_upsell: 'No'
-    sorts: [segment_lookup.grouping, opportunity_stage_history.opps_in_each_stage
-        desc 0]
-    limit: 3
-    dynamic_fields: [{table_calculation: conversion_rates, label: Conversion Rates,
-        expression: "${opportunity_stage_history.opps_in_each_stage}/ offset(${opportunity_stage_history.opps_in_each_stage},\
-          \ -1)", value_format: !!null '', value_format_name: percent_0, _kind_hint: measure,
-        _type_hint: number}]
-    query_timezone: America/Los_Angeles
-    stacking: ''
-    trellis: ''
-    color_application:
-      collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e
-      palette_id: 04e6ee8f-6a09-4649-891f-5bc66082e506
-      options:
-        steps: 5
-        reverse: false
-    show_value_labels: true
-    label_density: 25
-    legend_position: center
-    x_axis_gridlines: false
-    y_axis_gridlines: false
-    show_view_names: false
-    point_style: none
-    series_colors: {}
-    limit_displayed_rows: true
-    limit_displayed_rows_values:
-      show_hide: hide
-      first_last: first
-      num_rows: '1'
-    y_axes: [{label: '', orientation: left, series: [{id: Kevin Heller - 1 - conversion_rates,
-            name: Kevin Heller, axisId: conversion_rates}, {id: Rest of Named Accounts
-              - 2 - conversion_rates, name: Rest of Named Accounts, axisId: conversion_rates},
-          {id: Rest of Company - 3 - conversion_rates, name: Rest of Company, axisId: conversion_rates}],
-        showLabels: false, showValues: false, unpinAxis: false, tickDensity: default,
-        type: linear}]
-    y_axis_combined: true
-    show_y_axis_labels: false
-    show_y_axis_ticks: false
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: false
-    show_x_axis_ticks: true
-    x_axis_scale: auto
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    hidden_fields: [opportunity_stage_history.opps_in_each_stage]
-    listen:
-      Sales Rep: opportunity_owner.name_select
-    row: 18
-    col: 0
-    width: 12
     height: 8
   filters:
   - name: Sales Rep


### PR DESCRIPTION
In preparation for the demo, we want to be using 2019-Q1 data rather than 2019-Q2 (since that will be sparse due to it being the second say of the quarter). This means that a number of tiles needed to be converted to be use "last quarter"-esque filters rather than "this quarter" filters. 

Exact changes to each tile recorded on this Jira subtask:
AP-582