### PR TITLE
Create contact explore, and change "exclude_set" nomenclature to "exclusion_set"

### DIFF
--- a/account.explore.lkml
+++ b/account.explore.lkml
@@ -5,7 +5,7 @@ explore: account_core {
   view_name: account
   sql_always_where: NOT ${account.is_deleted}
     ;;
-  fields: [ALL_FIELDS*, -account_owner.user_exclude_set*, -creator.user_exclude_set*, -opportunity.opportunity_exclude_set*]
+  fields: [ALL_FIELDS*, -account_owner.user_exclusion_set*, -creator.user_exclusion_set*, -opportunity.opportunity_exclusion_set*, -account.account_exclusion_set*]
 
   join: sf_opportunity_facts {
     sql_on: ${account.id} = ${sf_opportunity_facts.account_id}  ;;

--- a/contact.explore.lkml
+++ b/contact.explore.lkml
@@ -1,0 +1,50 @@
+include: "contact_core.view.lkml"
+
+explore: contact_core {
+  extension: required
+  view_name: contact
+  sql_always_where: NOT ${contact.is_deleted} ;;
+
+  fields: [ALL_FIELDS*, -account_owner.user_exclusion_set*, -opportunity.opportunity_exclusion_set*, -account.account_exclusion_set*]
+
+  join: account {
+    sql_on: ${contact.account_id} = ${account.id} ;;
+    relationship: many_to_one
+  }
+
+  join: account_owner {
+    from: user
+    sql_on: ${account.owner_id} = ${account_owner.id} ;;
+    relationship: many_to_one
+  }
+
+  join: manager {
+    from: user
+    sql_on: ${account_owner.manager_id} = ${manager.id};;
+    fields: []
+    relationship: many_to_one
+  }
+
+  join: opportunity {
+    sql_on: ${account.id} = ${opportunity.account_id} ;;
+    relationship: one_to_many
+  }
+
+  join: opportunity_owner {
+    from: user
+    sql_on: ${opportunity.owner_id} = ${opportunity_owner.id} ;;
+    relationship: many_to_one
+  }
+
+  join: quota {
+    view_label: "Quota"
+    sql_on: ${quota.name} = ${opportunity_owner.name} ;;
+    relationship: one_to_one
+  }
+
+  join: quota_aggregation {
+    view_label: "Quota"
+    sql_on: ${quota_aggregation.ae_segment} = ${quota.ae_segment} ;;
+    relationship: one_to_one
+  }
+}

--- a/contact_core.view.lkml
+++ b/contact_core.view.lkml
@@ -3,8 +3,6 @@ view: contact_core {
   extends: [contact_adapter]
   # dimensions #
 
-  dimension_group: _fivetran_synced { hidden: yes }
-
   dimension: mailing_city { group_label: "Mailing Details" }
   dimension: mailing_country { group_label: "Mailing Details" }
   dimension: mailing_geocode_accuracy { group_label: "Mailing Details" }

--- a/historical_snapshot.explore.lkml
+++ b/historical_snapshot.explore.lkml
@@ -4,7 +4,7 @@ explore: historical_snapshot_core  {
   extension: required
   view_name: historical_snapshot
   label: "Historical Opportunity Snapshot"
-  fields: [ALL_FIELDS*,-opportunity.opportunity_exclude_set*,-account.account_exclusion_set*]
+  fields: [ALL_FIELDS*,-opportunity.opportunity_exclusion_set*,-account.account_exclusion_set*]
   join: opportunity {
     view_label: "Current Opportunity State"
     sql_on: ${historical_snapshot.opportunity_id} = ${opportunity.id} ;;

--- a/lead.explore.lkml
+++ b/lead.explore.lkml
@@ -3,7 +3,7 @@ include: "lead_core.view.lkml"
 explore: lead_core {
   extension: required
   view_name: lead
-  fields: [ALL_FIELDS*,-opportunity.opportunity_exclude_set*, -account.account_exclusion_set*]
+  fields: [ALL_FIELDS*,-opportunity.opportunity_exclusion_set*, -account.account_exclusion_set*]
   sql_always_where: NOT ${lead.is_deleted}
     ;;
 

--- a/opportunity_core.view.lkml
+++ b/opportunity_core.view.lkml
@@ -862,7 +862,7 @@ view: opportunity_core {
   set: opp_drill_set_open {
     fields: [opportunity.id, opportunity.name, opportunity_owner.name, account.name, created_date, type, days_as_opportunity, amount]
   }
-  set: opportunity_exclude_set {
+  set: opportunity_exclusion_set {
     fields: [percent_of_average_new_deal_size, percent_of_average_sales_cycle,logo64,logo,matches_name_select]
   }
 }

--- a/opportunity_history_waterfall.explore.lkml
+++ b/opportunity_history_waterfall.explore.lkml
@@ -4,7 +4,7 @@ explore: opportunity_history_waterfall_core {
   hidden:  yes
   extension: required
   view_name: opportunity_history_waterfall
-  fields: [ALL_FIELDS*,-opportunity.opportunity_exclude_set*, -account.account_exclusion_set*]
+  fields: [ALL_FIELDS*,-opportunity.opportunity_exclusion_set*, -account.account_exclusion_set*]
 
   # Filters out all opportunities that have a close date outside the timeframe we specify
   sql_always_where: (CASE WHEN ${closed_first} THEN 1 ELSE 0 END) = 0 AND ${closed_date_in_start_or_end} AND ${opportunity.is_included_in_quota} ;;

--- a/user_core.view.lkml
+++ b/user_core.view.lkml
@@ -111,7 +111,7 @@ view: user_core {
 
   # field sets for drilling #
 
-  set: user_exclude_set {
+  set: user_exclusion_set {
     fields: [manager,average_amount_pipeline,id_url,rep_comparitor]
   }
 }


### PR DESCRIPTION
Created a contact explore in the core project so that we can create a contacts report in the App. In doing so, realized that we have a number of sets named `viewName_exclude_set` and others named `viewName_exclusion_set`. Discussed with Spence, and decided to rename all sets to `exclusion_set`.