### PR TITLE
Removing quota.aggregate_quota from quota explore

### DIFF
--- a/quota_core.view.lkml
+++ b/quota_core.view.lkml
@@ -1,5 +1,6 @@
 # Quota Explore: Solely used for the Sales App Audit dashboard
 explore: quota {
+  hidden: yes
   fields: [ALL_FIELDS*, -quota.manager_quota, -quota.aggregate_quota]
 }
 

--- a/quota_core.view.lkml
+++ b/quota_core.view.lkml
@@ -1,6 +1,6 @@
 # Quota Explore: Solely used for the Sales App Audit dashboard
 explore: quota {
-  fields: [ALL_FIELDS*, -quota.manager_quota]
+  fields: [ALL_FIELDS*, -quota.manager_quota, -quota.aggregate_quota]
 }
 
 view: quota_core {


### PR DESCRIPTION
Created a quota explore for the Sales App audit dashboard (validation purposes). However, need to remove the quota.aggregate_quota field since it references the aggregate quota view.