### PR TITLE
Changing Dashboard title of "Pipeline Overview" to match sidebar label

### DIFF
--- a/application.json
+++ b/application.json
@@ -373,7 +373,7 @@
     },
     {
       "path": "sales-management-pipeline_management",
-      "title": "Management",
+      "title": "Pipeline Overview",
       "type": "dashboardCollection",
       "filters": [
         {


### PR DESCRIPTION
Currently the "Pipeline Overview" dash is named "Management". The title should be "Pipeline Overview" to match the sidebar label.
