### PR TITLE
Adding in name_id and name_display dimensions

### DIFF
--- a/opportunity_core.view.lkml
+++ b/opportunity_core.view.lkml
@@ -33,6 +33,38 @@ view: opportunity_core {
     value_format_name: custom_amount_value_format
   }
 
+  dimension: name_display {
+    type: string
+    sql: ${name} ;;
+
+    link: {
+      label: "Open in Salesforce"
+      url: "https://{{ salesforce_domain_config._sql }}/{{ opportunity.id._value }}"
+      icon_url: "https://www.google.com/s2/favicons?domain=www.salesforce.com"
+    }
+    link: {
+      label: "Open in Looker"
+      url: "/applications/sales-analytics/lookups-opportunity_lookup?filter[opportunity.name]={{ value | url_encode }}"
+      icon_url: "https://looker.com/favicon.ico"
+    }
+  }
+
+  dimension: name_id {
+    type: string
+    sql: CONCAT(${name},' (',SUBSTR(${id},-4,4), ')') ;;
+
+    link: {
+      label: "Open in Salesforce"
+      url: "https://{{ salesforce_domain_config._sql }}/{{ opportunity.id._value }}"
+      icon_url: "https://www.google.com/s2/favicons?domain=www.salesforce.com"
+    }
+    link: {
+      label: "Open in Looker"
+      url: "/applications/sales-analytics/lookups-opportunity_lookup?filter[opportunity.name]={{ value | url_encode }}"
+      icon_url: "https://looker.com/favicon.ico"
+    }
+  }
+
   dimension: matches_name_select {
     hidden: yes
     type:  yesno


### PR DESCRIPTION
We had an issue with the opportunity.name dimension where if / when opps have the same name, we would get repeated values selecting the name dimension (since it had liquid in its link parameter that would lead to fanout).

Solution is to create two fields, where name_id is used in cases where we want the name dimension in a table / as the grouping dimensions of a graph and name_display is used when the name of an opp is the title / headline of a dash.